### PR TITLE
Add the ability to specify separate rtmp & media (B & O) hosts

### DIFF
--- a/cmd/streamtester/streamtester.go
+++ b/cmd/streamtester/streamtester.go
@@ -30,7 +30,8 @@ func main() {
 	sim := flag.Uint("sim", 1, "Number of simulteneous streams to stream")
 	repeat := flag.Uint("repeat", 1, "Number of time to repeat")
 	profiles := flag.Int("profiles", 2, "Number of transcoding profiles configured on broadcaster")
-	host := flag.String("host", "localhost", "Broadcaster's host name")
+	bhost := flag.String("host", "localhost", "Broadcaster's host name")
+	ohost := flag.String("orch", "", "Orchestrator's host name - Broadcaster host will be used by default if not specified")
 	rtmp := flag.String("rtmp", "1935", "RTMP port number")
 	media := flag.String("media", "8935", "Media port number")
 	stime := flag.String("time", "", "Time to stream streams (40s, 4m, 24h45m). Not compatible with repeat option.")
@@ -124,6 +125,11 @@ func main() {
 		return
 	}
 
+	oHost := *ohost
+	if oHost == "" {
+		oHost = *bhost
+	}
+
 	var streamDuration time.Duration
 	if *stime != "" {
 		if streamDuration, err = server.ParseStreamDurationArgument(*stime); err != nil {
@@ -138,8 +144,8 @@ func main() {
 
 	defer glog.Infof("Exiting")
 	sr := testers.NewStreamer(*wowza)
-	// err = sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, *noBar, *latency, 3, 5*time.Second)
-	err = sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, false, *latency, *noBar, 3, 5*time.Second, waitForDur)
+	// err = sr.StartStreams(fn, *bhost, *rtmp, oHost, *media, *sim, *repeat, streamDuration, *noBar, *latency, 3, 5*time.Second)
+	err = sr.StartStreams(fn, *bhost, *rtmp, oHost, *media, *sim, *repeat, streamDuration, false, *latency, *noBar, 3, 5*time.Second, waitForDur)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -31,7 +31,7 @@ type Streamer2 interface {
 
 // Streamer interface
 type Streamer interface {
-	StartStreams(sourceFileName, host, rtmpPort, mediaPort string, simStreams, repeat uint, streamDuration time.Duration,
+	StartStreams(sourceFileName, bhost, rtmpPort, ohost, mediaPort string, simStreams, repeat uint, streamDuration time.Duration,
 		notFinal, measureLatency, noBar bool, groupStartBy int, startDelayBetweenGroups, waitForTarget time.Duration) error
 	Stats() *Stats
 	StatsFormatted() string
@@ -79,7 +79,8 @@ type Stats struct {
 // StartStreamsReq start streams request
 type StartStreamsReq struct {
 	FileName        string `json:"file_name"`
-	Host            string `json:"host"`
+	BHost           string `json:"host"`
+	OHost           string `json:"ohost"`
 	RTMP            int    `json:"rtmp"`
 	Media           int    `json:"media"`
 	Repeat          uint   `json:"repeat"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,10 +116,13 @@ func (ss *StreamerServer) handleStartStreams(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	glog.Infof("Start streams request %+v", *ssr)
-	if ssr.Host == "" {
+	if ssr.BHost == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("Should specify 'host' field"))
 		return
+	}
+	if ssr.OHost == "" {
+		ssr.OHost = ssr.BHost
 	}
 	if ssr.Repeat <= 0 {
 		ssr.Repeat = 1
@@ -158,7 +161,7 @@ func (ss *StreamerServer) handleStartStreams(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	ss.streamer.StartStreams(ssr.FileName, ssr.Host, strconv.Itoa(ssr.RTMP), strconv.Itoa(ssr.Media), ssr.Simultaneous,
+	ss.streamer.StartStreams(ssr.FileName, ssr.BHost, strconv.Itoa(ssr.RTMP), ssr.OHost, strconv.Itoa(ssr.Media), ssr.Simultaneous,
 		ssr.Repeat, streamDuration, true, ssr.MeasureLatency, true, 3, 5*time.Second, 0)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/testers/streamer.go
+++ b/internal/testers/streamer.go
@@ -53,7 +53,7 @@ func (sr *streamer) Stop() {
 	}
 }
 
-func (sr *streamer) StartStreams(sourceFileName, host, rtmpPort, mediaPort string, simStreams, repeat uint, streamDuration time.Duration,
+func (sr *streamer) StartStreams(sourceFileName, bhost, rtmpPort, ohost, mediaPort string, simStreams, repeat uint, streamDuration time.Duration,
 	notFinal, measureLatency, noBar bool, groupStartBy int, startDelayBetweenGroups, waitForTarget time.Duration) error {
 
 	showProgress := !noBar
@@ -95,7 +95,7 @@ func (sr *streamer) StartStreams(sourceFileName, host, rtmpPort, mediaPort strin
 			if repeat > 1 {
 				glog.Infof("Starting %d streaming session", i)
 			}
-			err := sr.startStreams(sourceFileName, host, nRtmpPort, nMediaPort, simStreams, showProgress, measureLatency,
+			err := sr.startStreams(sourceFileName, bhost, ohost, nRtmpPort, nMediaPort, simStreams, showProgress, measureLatency,
 				segments, groupStartBy, startDelayBetweenGroups, waitForTarget)
 			if err != nil {
 				glog.Fatal(err)
@@ -114,11 +114,11 @@ func (sr *streamer) StartStreams(sourceFileName, host, rtmpPort, mediaPort strin
 	return nil
 }
 
-func (sr *streamer) startStreams(sourceFileName, host string, nRtmpPort, nMediaPort int, simStreams uint, showProgress,
+func (sr *streamer) startStreams(sourceFileName, bhost, ohost string, nRtmpPort, nMediaPort int, simStreams uint, showProgress,
 	measureLatency bool, totalSegments int, groupStartBy int, startDelayBetweenGroups, waitForTarget time.Duration) error {
 
-	// fmt.Printf("Starting streaming %s to %s:%d, number of streams is %d\n", sourceFileName, host, nRtmpPort, simStreams)
-	msg := fmt.Sprintf("Starting streaming %s to %s:%d, number of streams is %d\n", sourceFileName, host, nRtmpPort, simStreams)
+	// fmt.Printf("Starting streaming %s to %s:%d, number of streams is %d\n", sourceFileName, bhost, nRtmpPort, simStreams)
+	msg := fmt.Sprintf("Starting streaming %s to %s:%d, number of streams is %d\n", sourceFileName, bhost, nRtmpPort, simStreams)
 	messenger.SendMessage(msg)
 	fmt.Println(msg)
 	rtmpURLTemplate := "rtmp://%s:%d/%s"
@@ -139,8 +139,8 @@ func (sr *streamer) startStreams(sourceFileName, host string, nRtmpPort, nMediaP
 				time.Sleep(startDelayBetweenGroups)
 			}
 			manifesID := fmt.Sprintf("%s_%d", baseManfistID, i)
-			rtmpURL := fmt.Sprintf(rtmpURLTemplate, host, nRtmpPort, manifesID)
-			mediaURL := fmt.Sprintf(mediaURLTemplate, host, nMediaPort, manifesID)
+			rtmpURL := fmt.Sprintf(rtmpURLTemplate, bhost, nRtmpPort, manifesID)
+			mediaURL := fmt.Sprintf(mediaURLTemplate, ohost, nMediaPort, manifesID)
 			glog.Infof("RTMP: %s", rtmpURL)
 			glog.Infof("MEDIA: %s", mediaURL)
 			var bar *uiprogress.Bar


### PR DESCRIPTION
Currently, stream-tester assumes that the broadcaster and orchestrator nodes are hosted on the same machine.  It takes a "host" string argument along with "rtmp" & "media" integer arguments that designate the ports to be used on the single host.

This adds a new field for the media / orchestrator host name to be used in addition to the existing field that is used for the rtmp / broadcaster host name.

This was done in a fully-backward compatible way - If the new field is not provided, the application will continue to function with its original behavior.

blocks https://github.com/livepeer/livepeer-infra/issues/32
closes https://github.com/livepeer/stream-tester/issues/14