### PR TITLE
Changes to server implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Params:
  - `-time` Time to stream streams (40s, 4m, 24h45m). Not compatible with repeat option
 
 ### Infinite stream testing mode
-In this mode streaming is stopped only on error, so it will be infinite if transcoding is done ideally.
+In this mode Stream Tester streams video to RTMP ingest point and read HLS stream back. Streaming is stopped only on error, so it will be infinite if transcoding is done ideally.
 
 Errors can be reported to Discord.
 
@@ -70,6 +70,13 @@ Params:
  - `discord-user-name` User name to use when sending messages to Discord
  - `gsbucket` Google Storage bucket (to store segments that was not successfully parsed)
  - `gskey` Google Storage private key (in json format (actual key, not file name))
+
+### Infinite HLS pull testing mode
+In this mode Stream Tester pulls arbitrary HLS stream and runs same checks as in previous mode.
+To use it specify `-media-url` without specifying `-rtmp-url`.
+
+
+
 
 ### Saving arbitrary stream to file
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Params:
  - `-time` Time to stream streams (40s, 4m, 24h45m). Not compatible with repeat option
 
 ### Infinite stream testing mode
-In this mode Stream Tester streams video to RTMP ingest point and read HLS stream back. Streaming is stopped only on error, so it will be infinite if transcoding is done ideally.
+In this mode streaming is stopped only on error, so it will be infinite if transcoding is done ideally.
 
 Errors can be reported to Discord.
 
@@ -70,13 +70,6 @@ Params:
  - `discord-user-name` User name to use when sending messages to Discord
  - `gsbucket` Google Storage bucket (to store segments that was not successfully parsed)
  - `gskey` Google Storage private key (in json format (actual key, not file name))
-
-### Infinite HLS pull testing mode
-In this mode Stream Tester pulls arbitrary HLS stream and runs same checks as in previous mode.
-To use it specify `-media-url` without specifying `-rtmp-url`.
-
-
-
 
 ### Saving arbitrary stream to file
 

--- a/cmd/streamtester/streamtester.go
+++ b/cmd/streamtester/streamtester.go
@@ -165,6 +165,7 @@ func main() {
 		}
 		fmt.Println(msg)
 	}
+
 	if *noExit {
 		s := server.NewStreamerServer(*wowza)
 		s.StartWebServer(*serverAddr)

--- a/cmd/streamtester/streamtester.go
+++ b/cmd/streamtester/streamtester.go
@@ -89,6 +89,7 @@ func main() {
 	if len(flag.Args()) > 0 {
 		fn = flag.Arg(0)
 	}
+	model.ProfilesNum = *profiles
 	var err error
 	var waitForDur time.Duration
 	if *waitForTarget != "" {
@@ -100,6 +101,13 @@ func main() {
 	testers.IgnoreNoCodecError = *ignoreNoCodecError
 	testers.IgnoreGaps = *ignoreGaps
 	testers.IgnoreTimeDrift = *ignoreTimeDrift
+	if *mediaURL != "" && *rtmpURL == "" {
+		msg := fmt.Sprintf(`Starting infinite stream to %s`, *mediaURL)
+		messenger.SendMessage(msg)
+		sr2 := testers.NewStreamer2(*wowza)
+		sr2.StartPulling(*mediaURL)
+		return
+	}
 	if *rtmpURL != "" {
 		if *mediaURL == "" {
 			glog.Fatal("Should also specifiy -media-url")
@@ -129,7 +137,6 @@ func main() {
 	glog.Infof("Starting stream tester, file %s number of streams is %d, repeat %d times no bar %v", fn, *sim, *repeat, *noBar)
 
 	defer glog.Infof("Exiting")
-	model.ProfilesNum = *profiles
 	sr := testers.NewStreamer(*wowza)
 	// err = sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, *noBar, *latency, 3, 5*time.Second)
 	err = sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, false, *latency, *noBar, 3, 5*time.Second, waitForDur)

--- a/cmd/streamtester/streamtester.go
+++ b/cmd/streamtester/streamtester.go
@@ -89,7 +89,6 @@ func main() {
 	if len(flag.Args()) > 0 {
 		fn = flag.Arg(0)
 	}
-	model.ProfilesNum = *profiles
 	var err error
 	var waitForDur time.Duration
 	if *waitForTarget != "" {
@@ -101,13 +100,6 @@ func main() {
 	testers.IgnoreNoCodecError = *ignoreNoCodecError
 	testers.IgnoreGaps = *ignoreGaps
 	testers.IgnoreTimeDrift = *ignoreTimeDrift
-	if *mediaURL != "" && *rtmpURL == "" {
-		msg := fmt.Sprintf(`Starting infinite stream to %s`, *mediaURL)
-		messenger.SendMessage(msg)
-		sr2 := testers.NewStreamer2(*wowza)
-		sr2.StartPulling(*mediaURL)
-		return
-	}
 	if *rtmpURL != "" {
 		if *mediaURL == "" {
 			glog.Fatal("Should also specifiy -media-url")
@@ -137,21 +129,14 @@ func main() {
 	glog.Infof("Starting stream tester, file %s number of streams is %d, repeat %d times no bar %v", fn, *sim, *repeat, *noBar)
 
 	defer glog.Infof("Exiting")
+	model.ProfilesNum = *profiles
 	sr := testers.NewStreamer(*wowza)
 	// err = sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, *noBar, *latency, 3, 5*time.Second)
-	err = sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, false, *latency, *noBar, 3, 5*time.Second, waitForDur)
+	baseManifestID, err := sr.StartStreams(fn, *host, *rtmp, *media, *sim, *repeat, streamDuration, false, *latency, *noBar, 3, 5*time.Second, waitForDur)
 	if err != nil {
 		glog.Fatal(err)
 	}
-	/*
-		go func() {
-			for {
-				time.Sleep(25 * time.Second)
-				// fmt.Println(sr.Stats().FormatForConsole())
-				// fmt.Println(sr.DownStatsFormatted())
-			}
-		}()
-	*/
+
 	// Catch interrupt signal to shut down transcoder
 	exitc := make(chan os.Signal, 1)
 	signal.Notify(exitc, os.Interrupt)
@@ -164,9 +149,9 @@ func main() {
 	<-sr.Done()
 	time.Sleep(2 * time.Second)
 	fmt.Println("========= Stats: =========")
-	stats := sr.Stats()
+	stats := sr.Stats(baseManifestID)
+
 	fmt.Println(stats.FormatForConsole())
-	// fmt.Println(sr.AnalyzeFormatted(false))
 	if *latencyThreshold > 0 && stats.TranscodedLatencies.P95 > 0 {
 		// check latencies, report failure or success
 		var msg string
@@ -184,5 +169,4 @@ func main() {
 		s := server.NewStreamerServer(*wowza)
 		s.StartWebServer(*serverAddr)
 	}
-	// messenger.SendMessage(sr.AnalyzeFormatted(true))
 }

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -25,6 +25,8 @@ type InfinitePuller interface {
 // Streamer2 interface
 type Streamer2 interface {
 	StartStreaming(sourceFileName string, rtmpIngestURL, mediaURL string, waitForTarget time.Duration)
+	// StartPulling pull arbitrary HLS stream and report found errors
+	StartPulling(mediaURL string)
 }
 
 // Streamer interface

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -25,18 +25,14 @@ type InfinitePuller interface {
 // Streamer2 interface
 type Streamer2 interface {
 	StartStreaming(sourceFileName string, rtmpIngestURL, mediaURL string, waitForTarget time.Duration)
-	// StartPulling pull arbitrary HLS stream and report found errors
-	StartPulling(mediaURL string)
 }
 
 // Streamer interface
 type Streamer interface {
 	StartStreams(sourceFileName, host, rtmpPort, mediaPort string, simStreams, repeat uint, streamDuration time.Duration,
-		notFinal, measureLatency, noBar bool, groupStartBy int, startDelayBetweenGroups, waitForTarget time.Duration) error
-	Stats() *Stats
-	StatsFormatted() string
-	DownStatsFormatted() string
-	AnalyzeFormatted(short bool) string
+		notFinal, measureLatency, noBar bool, groupStartBy int, startDelayBetweenGroups, waitForTarget time.Duration) (string, error)
+	Stats(baseManifestID string) *Stats
+	AllStats() map[string]*Stats
 	Done() <-chan struct{}
 	Stop() // Stop active streams
 	Cancel()
@@ -53,7 +49,7 @@ type Latencies struct {
 // Stats represents global test statistics
 type Stats struct {
 	RTMPActiveStreams            int             `json:"rtmp_active_streams"` // number of active RTMP streams
-	RTMPstreams                  int             `json:"rtm_pstreams"`        // number of RTMP streams
+	RTMPstreams                  int             `json:"rtmp_streams"`        // number of RTMP streams
 	MediaStreams                 int             `json:"media_streams"`       // number of media streams
 	TotalSegmentsToSend          int             `json:"total_segments_to_send"`
 	SentSegments                 int             `json:"sent_segments"`
@@ -72,6 +68,7 @@ type Stats struct {
 	RawTranscodedLatencies       []time.Duration `json:"raw_transcoded_latencies"`
 	WowzaMode                    bool            `json:"wowza_mode"`
 	Gaps                         int             `json:"gaps"`
+	StartTime                    time.Time       `json:"start_time"`
 }
 
 // REST requests
@@ -88,6 +85,16 @@ type StartStreamsReq struct {
 	ProfilesNum     int    `json:"profiles_num"`
 	DoNotClearStats bool   `json:"do_not_clear_stats"`
 	MeasureLatency  bool   `json:"measure_latency"`
+}
+
+// StartStreamsRes start streams response
+type StartStreamsRes struct {
+	Success        bool   `json:"success"`
+	BaseManifestID string `json:"base_manifest_id"`
+}
+
+type StatsReq struct {
+	BaseManifestID string `json:"base_manifest_id"`
 }
 
 // FormatForConsole formats stats to be shown in console

--- a/internal/testers/m3utester.go
+++ b/internal/testers/m3utester.go
@@ -851,7 +851,6 @@ func (md *mediaDownloader) downloadSegment(task *downloadTask, res chan download
 					latency = now.Sub(st)
 					md.latencies = append(md.latencies, latency)
 				}
-				// glog.Infof("== downloaded segment seqNo %d segment start time %s latency %s current time %s", task.seqNo, fsttim, latency, now)
 			}
 		}
 

--- a/internal/testers/m3utester2.go
+++ b/internal/testers/m3utester2.go
@@ -460,12 +460,7 @@ func (ms *m3uMediaStream) workerLoop(masterDR chan *downloadResult, latencyResul
 					return
 				}
 			}
-			var latency time.Duration
-			var speedRatio float64
-			var merr error
-			if ms.segmentsMatcher != nil {
-				latency, speedRatio, merr = ms.segmentsMatcher.matchSegment(dres.startTime, dres.duration, dres.downloadCompetedAt)
-			}
+			latency, speedRatio, merr := ms.segmentsMatcher.matchSegment(dres.startTime, dres.duration, dres.downloadCompetedAt)
 			glog.Infof(`%s seqNo %4d latency is %s speedRatio is %v`, dres.resolution, dres.seqNo, latency, speedRatio)
 			if merr != nil {
 				glog.Infof("downloaded: %+v", dres)
@@ -473,9 +468,7 @@ func (ms *m3uMediaStream) workerLoop(masterDR chan *downloadResult, latencyResul
 				panic(merr)
 				continue
 			}
-			if ms.segmentsMatcher != nil {
-				latencyResults <- &latencyResult{name: dres.name, resolution: ms.resolution, seqNo: dres.seqNo, latency: latency, speedRatio: speedRatio}
-			}
+			latencyResults <- &latencyResult{name: dres.name, resolution: ms.resolution, seqNo: dres.seqNo, latency: latency, speedRatio: speedRatio}
 			// masterDR <- dres
 			results = append(results, dres)
 			sort.Sort(results)
@@ -490,7 +483,7 @@ func (ms *m3uMediaStream) workerLoop(masterDR chan *downloadResult, latencyResul
 			for i, r := range results {
 				problem = ""
 				tillNext = 0
-				if i < len(results)-2 {
+				if i < len(results)-1 {
 					ns := results[i+1]
 					tillNext = ns.startTime - r.startTime
 					if tillNext > 0 && !isTimeEqualM(r.duration, tillNext) {
@@ -506,7 +499,7 @@ func (ms *m3uMediaStream) workerLoop(masterDR chan *downloadResult, latencyResul
 				// 	ms.fatalEnd(msg)
 				// 	return
 				// }
-				if problem != "" && i < len(results)-6 {
+				if problem != "" && i < len(results)-6 && fatalProblem == "" {
 					fatalProblem = msg
 					// break
 				}
@@ -595,7 +588,6 @@ func (ms *m3uMediaStream) manifestPullerLoop(wowzaMode bool) {
 		// glog.Infof("Got media playlist %s with %d (really %d) segments of url %s:", ms.resolution, len(pl.Segments), countSegments(pl), surl)
 		// glog.Info(pl)
 		now := time.Now()
-		var lastTimeDownloadStarted time.Time
 		for i, segment := range pl.Segments {
 			if segment != nil {
 				// glog.Infof("Segment: %+v", *segment)
@@ -604,7 +596,7 @@ func (ms *m3uMediaStream) manifestPullerLoop(wowzaMode bool) {
 					segment.URI = wowzaSessionRE.ReplaceAllString(segment.URI, "_")
 				}
 				if i == 0 && !seenAtFirst.Contains(segment.URI) && seen.Contains(segment.URI) {
-					glog.V(model.DEBUG).Infof("===> segment at first place %s (%s) seq %d", segment.URI, ms.resolution, pl.SeqNo)
+					glog.Infof("===> segment at first place %s (%s) seq %d", segment.URI, ms.resolution, pl.SeqNo)
 					ms.downloadResults <- &downloadResult{timeAtFirstPlace: now, name: segment.URI, seqNo: pl.SeqNo, status: "200 OK"}
 					seenAtFirst.Add(segment.URI)
 					continue
@@ -614,12 +606,8 @@ func (ms *m3uMediaStream) manifestPullerLoop(wowzaMode bool) {
 				}
 				seen.Add(segment.URI)
 				lastTimeNewSegmentSeen = time.Now()
-				if time.Since(lastTimeDownloadStarted) < 50*time.Millisecond {
-					time.Sleep(50 * time.Millisecond)
-				}
 				dTask := &downloadTask{baseURL: ms.u, url: segment.URI, seqNo: pl.SeqNo + uint64(i), title: segment.Title, duration: segment.Duration, appTime: now}
 				go downloadSegment(dTask, ms.downloadResults)
-				lastTimeDownloadStarted = time.Now()
 				now = now.Add(time.Millisecond)
 				// glog.V(model.VERBOSE).Infof("segment %s is of length %f seqId=%d", segment.URI, segment.Duration, segment.SeqId)
 			}

--- a/internal/testers/rtmp_streamer.go
+++ b/internal/testers/rtmp_streamer.go
@@ -32,6 +32,7 @@ type rtmpStreamer struct {
 	wowzaMode       bool
 	segmentsMatcher *segmentsMatcher
 	hasBar          bool
+	started         time.Time
 }
 
 // source is local file name for now
@@ -149,6 +150,7 @@ func (rs *rtmpStreamer) startUpload(fn, rtmpURL string, segmentsToStream int, wa
 	// conn, err := rtmp.Dial("rtmp://localhost:1935/" + manifestID)
 	// conn, err := rtmp.Dial(rtmpURL)
 	started := time.Now()
+	rs.started = started
 	for {
 		conn, err = rtmp.DialTimeout(rtmpURL, 4*time.Second)
 		if err != nil {

--- a/internal/testers/streamer.go
+++ b/internal/testers/streamer.go
@@ -161,10 +161,9 @@ func (sr *streamer) startStreams(baseManifestID string, sourceFileName, host str
 				bar = uiprogress.AddBar(totalSegments).AppendCompleted().PrependElapsed()
 			}
 			done := make(chan struct{})
-			var sentTimesMap *utils.SyncedTimesMap
-			if measureLatency {
-				sentTimesMap = utils.NewSyncedTimesMap()
-			}
+
+			sentTimesMap := utils.NewSyncedTimesMap()
+
 			up := newRtmpStreamer(rtmpURL, sourceFileName, sentTimesMap, bar, done, sr.wowzaMode, nil)
 			wg.Add(1)
 			go func() {
@@ -226,7 +225,7 @@ func (sr *streamer) Stats(baseManifestID string) *model.Stats {
 		StartTime:           sr.uploaders[baseManifestID][baseManifestID+"_0"].started,
 	}
 	for _, rs := range sr.uploaders[baseManifestID] {
-		// Broadcaster always skips at lest first segment, and potentially more
+		// Broadcaster always skips at least first segment, and potentially more
 		stats.SentSegments += rs.counter.segments - rs.skippedSegments
 		if rs.connectionLost {
 			stats.ConnectionLost++
@@ -255,8 +254,6 @@ func (sr *streamer) Stats(baseManifestID string) *model.Stats {
 			}
 		}
 	}
-	// glog.Infof("=== source latencies: %+v", sourceLatencies)
-	// glog.Infof("=== transcoded latencies: %+v", transcodedLatencies)
 	sourceLatencies.Prepare()
 	transcodedLatencies.Prepare()
 	avg, p50, p95, p99 := sourceLatencies.Calc()
@@ -264,12 +261,16 @@ func (sr *streamer) Stats(baseManifestID string) *model.Stats {
 	avg, p50, p95, p99 = transcodedLatencies.Calc()
 	stats.TranscodedLatencies = model.Latencies{Avg: avg, P50: p50, P95: p95, P99: p99}
 	if stats.SentSegments > 0 {
-		stats.SuccessRate = float64(stats.DownloadedSegments) / (float64(model.ProfilesNum) * float64(stats.SentSegments)) * 100
+		stats.SuccessRate = float64(stats.DownloadedSegments) / ((float64(model.ProfilesNum) + 1) * float64(stats.SentSegments)) * 100
 	}
-	stats.ShouldHaveDownloadedSegments = (model.ProfilesNum) * stats.SentSegments
+	stats.ShouldHaveDownloadedSegments = (model.ProfilesNum + 1) * stats.SentSegments
 	stats.ProfilesNum = model.ProfilesNum
 	stats.RawSourceLatencies = sourceLatencies.Raw()
 	stats.RawTranscodedLatencies = transcodedLatencies.Raw()
+	// remove stats when finished
+	if stats.Finished {
+		defer sr.removeStats(baseManifestID)
+	}
 	return stats
 }
 
@@ -279,4 +280,17 @@ func randName() string {
 		x[i] = byte(rand.Uint32())
 	}
 	return fmt.Sprintf("%x", x)
+}
+
+func (sr *streamer) removeStats(baseManifestID string) {
+	// keep the stats for an arbitrary set of time before removing for external availability purposes
+	go func() {
+		time.Sleep(1 * time.Minute)
+		if _, ok := sr.downloaders[baseManifestID]; ok {
+			delete(sr.downloaders, baseManifestID)
+		}
+		if _, ok := sr.uploaders[baseManifestID]; ok {
+			delete(sr.uploaders, baseManifestID)
+		}
+	}()
 }

--- a/internal/testers/streamer2.go
+++ b/internal/testers/streamer2.go
@@ -55,15 +55,6 @@ func (sr *streamer2) StartStreaming(sourceFileName string, rtmpIngestURL, mediaU
 	messenger.SendMessage(msg)
 }
 
-// StartPulling pull arbitrary HLS stream and report found errors
-func (sr *streamer2) StartPulling(mediaURL string) {
-	sr.downloader = newM3utester2(mediaURL, sr.wowzaMode, sr.eof, 0, nil) // starts to download at creation
-	started := time.Now()
-	<-sr.eof
-	msg := fmt.Sprintf(`Streaming stopped after %s`, time.Since(started))
-	messenger.SendMessage(msg)
-}
-
 func (sr *streamer2) waitForTCP(waitForTarget time.Duration, rtmpIngestURL string) error {
 	var u *url.URL
 	var err error

--- a/internal/testers/streamer2.go
+++ b/internal/testers/streamer2.go
@@ -55,6 +55,15 @@ func (sr *streamer2) StartStreaming(sourceFileName string, rtmpIngestURL, mediaU
 	messenger.SendMessage(msg)
 }
 
+// StartPulling pull arbitrary HLS stream and report found errors
+func (sr *streamer2) StartPulling(mediaURL string) {
+	sr.downloader = newM3utester2(mediaURL, sr.wowzaMode, sr.eof, 0, nil) // starts to download at creation
+	started := time.Now()
+	<-sr.eof
+	msg := fmt.Sprintf(`Streaming stopped after %s`, time.Since(started))
+	messenger.SendMessage(msg)
+}
+
 func (sr *streamer2) waitForTCP(waitForTarget time.Duration, rtmpIngestURL string) error {
 	var u *url.URL
 	var err error


### PR DESCRIPTION
This PR made significant changes to the server implementation of the `stream-tester`. These changes accomplish the requirements for https://github.com/livepeer/labrador _without taking into account backward compatibility requirements_ , therefore not all changes in this PR might be compatible with the current CLI implementation. 

Major changes:

- storing `streamer.uploaders` and `streamer.downloaders` in a map instead of a slice, with `baseManifestID` as key so that we can request stats for a manifest ID, remove map entries when a stream is finished [1]
- Changed stats endpoint to take in a manifestID in the request
- Always measure latencies (this would likely have to be changed back, but be made always available on the server)

[1] Labrador has a script that will keep querying the `/stats` endpoint for a `baseManifestID` until `finished == true` and writes the stats to a sqlite DB. This extra service isn't really necessary as it just provides Database R/W and forwards requests to the `stream-tester` and DB storage could be included here instead as an option when running in server mode. At the time it was however the fastest way to get a working MVP. 