### PR TITLE
Add stream-monitor binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.mp4
 *.ts
 /streamtester
+.DS_Store
+tmp
+.cache
+.ash_history
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$vers
 RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/testdriver/testdriver.go
 RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/mist-api-connector/mist-api-connector.go
 RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/loadtester/loadtester.go
+RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/stream-monitor/stream-monitor.go
 # RUN ls -a /usr
 # RUN find / -name libavformat.so.58
 
@@ -44,6 +45,7 @@ COPY --from=builder /root/streamtester streamtester
 COPY --from=builder /root/testdriver testdriver
 COPY --from=builder /root/mist-api-connector mist-api-connector
 COPY --from=builder /root/loadtester loadtester
+COPY --from=builder /root/stream-monitor stream-monitor
 # COPY --from=builder /usr/lib/libavformat.so.58 /usr/lib/libavformat.so.58
 # COPY --from=builder /usr/lib/libavutil.so.56 /usr/lib/libavutil.so.56
 # COPY --from=builder /usr/lib/libavcodec.so.58 /usr/lib/libavcodec.so.58

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,7 @@ push:
 .PHONY: localdocker
 localdocker:
 	docker build -f Dockerfile.debian -t livepeer/streamtester:latest --build-arg version=$(shell git describe --dirty) .
+
+.PHONY: stream-monitor
+monitor:
+	go build -ldflags="$(ldflags)" cmd/stream-monitor/stream-monitor.go

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -148,11 +148,15 @@ func main() {
     done <- true
   }()
 
+  // run stream cycles until interupt or panic
   for {
     go startStream()
-    <-streamDone
-  }
 
-  <-done
-  os.Exit(model.ExitCode)
+    select {
+    case <-streamDone:
+        fmt.Println("Stream Cycle Complete")
+    case <-done:
+      os.Exit(model.ExitCode)
+    }
+  }
 }

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -66,7 +66,8 @@ func main() {
   fmt.Printf("Hostname %s OS %s IPs %v\n", hostName, runtime.GOOS, utils.GetIPs())
   fmt.Printf("Production: %v\n", model.Production)
 
-  gctx, _ := context.WithCancel(context.Background()) // to be used as global parent context, in the future
+  gctx, gcancel := context.WithCancel(context.Background()) // to be used as global parent context, in the future
+  defer gcancel()
 
   metrics.InitCensus(hostName, model.Version)
 

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -2,162 +2,169 @@
 package main
 
 import (
-  "context"
-  "flag"
-  "fmt"
-  "os"
-  "os/signal"
-  "runtime"
-  "syscall"
-  "time"
-  "github.com/golang/glog"
-  "github.com/livepeer/joy4/format"
-  "github.com/livepeer/stream-tester/apis/livepeer"
-  "github.com/livepeer/stream-tester/internal/metrics"
-  "github.com/livepeer/stream-tester/internal/testers"
-  "github.com/livepeer/stream-tester/internal/utils"
-  "github.com/livepeer/stream-tester/internal/server"
-  "github.com/livepeer/stream-tester/model"
-  "github.com/peterbourgon/ff/v2"
+	"context"
+	"flag"
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/livepeer/joy4/format"
+	"github.com/livepeer/stream-tester/apis/livepeer"
+	"github.com/livepeer/stream-tester/internal/metrics"
+	"github.com/livepeer/stream-tester/internal/server"
+	"github.com/livepeer/stream-tester/internal/testers"
+	"github.com/livepeer/stream-tester/internal/utils"
+	"github.com/livepeer/stream-tester/model"
+	"github.com/peterbourgon/ff/v2"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
 )
 
 func init() {
-  format.RegisterAll()
+	format.RegisterAll()
 
-  // override glog's default -logtostderr flag
-  flag.Set("logtostderr", "true")
+	// override glog's default -logtostderr flag
+	err := flag.Set("logtostderr", "true")
+	if err != nil {
+		panic(err)
+	}
 
-  model.ProfilesNum = 1
+	model.ProfilesNum = 1
 }
 
 func main() {
-  var err error
+	var err error
 
-  fs := flag.NewFlagSet("stream-monitor", flag.ExitOnError)
+	fs := flag.NewFlagSet("stream-monitor", flag.ExitOnError)
 
-  apiServer := fs.String("api-server", "livepeer.com", "Server of the Livepeer API to be used")
-  apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used")
-  bind := fs.String("bind", "0.0.0.0:9090", "Address to bind metric server to")
-  fileArg := fs.String("file", "bbb_sunflower_1080p_30fps_normal_t02.mp4", "File to stream")
-  streamDuration := fs.Duration("stream-duration", 0, "How long to stream (0 to stream whole file)")
-  verbosity := fs.String("v", "", "Log verbosity.  {4|5|6}")
-  version := fs.Bool("version", false, "Print out the version")
+	apiServer := fs.String("api-server", "livepeer.com", "Server of the Livepeer API to be used")
+	apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used")
+	bind := fs.String("bind", "0.0.0.0:9090", "Address to bind metric server to")
+	fileArg := fs.String("file", "bbb_sunflower_1080p_30fps_normal_t02.mp4", "File to stream")
+	streamDuration := fs.Duration("stream-duration", 0, "How long to stream (0 to stream whole file)")
+	verbosity := fs.String("v", "", "Log verbosity.  {4|5|6}")
+	version := fs.Bool("version", false, "Print out the version")
 
-  _ = fs.String("config", "", "config file (optional)")
-  ff.Parse(
-    fs,
-    os.Args[1:],
-    ff.WithConfigFileFlag("config"),
-    ff.WithConfigFileParser(ff.PlainParser),
-    ff.WithEnvVarPrefix("STREAM_MONITOR"),
-  )
+	_ = fs.String("config", "", "config file (optional)")
+	_ = ff.Parse(
+		fs,
+		os.Args[1:],
+		ff.WithConfigFileFlag("config"),
+		ff.WithConfigFileParser(ff.PlainParser),
+		ff.WithEnvVarPrefix("STREAM_MONITOR"),
+	)
 
-  // configure glog
-  vFlag := flag.Lookup("v")
-  vFlag.Value.Set(*verbosity)
-  // supress errors in log output from glog
-  flag.CommandLine.Parse(nil)
+	// configure glog
+	vFlag := flag.Lookup("v")
+	_ = vFlag.Value.Set(*verbosity)
 
-  hostName, _ := os.Hostname()
+	// supress errors in log output from glog
+	err = flag.CommandLine.Parse(nil)
+	if err != nil {
+		panic(err)
+	}
 
-  // Print startup
-  fmt.Println("StreamMonitor version: " + model.Version)
-  fmt.Printf("Compiler version: %s %s\n", runtime.Compiler, runtime.Version())
-  fmt.Printf("Hostname %s OS %s IPs %v\n", hostName, runtime.GOOS, utils.GetIPs())
-  fmt.Printf("Production: %v\n", model.Production)
+	hostName, _ := os.Hostname()
 
-  gctx, gcancel := context.WithCancel(context.Background()) // to be used as global parent context, in the future
-  defer gcancel()
+	// Print startup
+	fmt.Println("StreamMonitor version: " + model.Version)
+	fmt.Printf("Compiler version: %s %s\n", runtime.Compiler, runtime.Version())
+	fmt.Printf("Hostname %s OS %s IPs %v\n", hostName, runtime.GOOS, utils.GetIPs())
+	fmt.Printf("Production: %v\n", model.Production)
 
-  metrics.InitCensus(hostName, model.Version)
+	gctx, gcancel := context.WithCancel(context.Background()) // to be used as global parent context, in the future
+	defer gcancel()
 
-  metricServer := server.NewMetricsServer()
-  go metricServer.Start(gctx, *bind)
+	metrics.InitCensus(hostName, model.Version)
 
-  if *version {
-    return
-  }
+	metricServer := server.NewMetricsServer()
+	go metricServer.Start(gctx, *bind)
 
-  if _, err := os.Stat(*fileArg); os.IsNotExist(err) {
-    fmt.Printf("File '%s' does not exists", *fileArg)
-    os.Exit(1)
-  }
+	if *version {
+		return
+	}
 
-  if *apiToken == "" {
-    glog.Fatalf("-api-token should be specified")
-  }
+	if _, err := os.Stat(*fileArg); os.IsNotExist(err) {
+		fmt.Printf("File '%s' does not exists", *fileArg)
+		os.Exit(1)
+	}
 
-  streamDone := make(chan bool, 1)
-  done := make(chan bool, 1)
-  sigs := make(chan os.Signal)
-  lapi := livepeer.NewLivepeer(*apiToken, *apiServer, nil)
+	if *apiToken == "" {
+		glog.Fatalf("-api-token should be specified")
+	}
 
-  var stream livepeer.CreateStreamResp
+	streamDone := make(chan bool, 1)
+	done := make(chan bool, 1)
+	sigs := make(chan os.Signal)
+	lapi := livepeer.NewLivepeer(*apiToken, *apiServer, nil)
 
-  startStream := func() {
-    lapi.Init()
-    glog.Infof("Choosen server: %s", lapi.GetServer())
-    ingests, err := lapi.Ingest(false)
-    if err != nil {
-      panic(err)
-    }
-    glog.Infof("Got ingests: %+v", ingests)
-    broadcasters, err := lapi.Broadcasters()
-    if err != nil {
-      panic(err)
-    }
-    glog.Infof("Got broadcasters: %+v", broadcasters)
-    streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format(time.RFC3339Nano))
-    stream, err := lapi.CreateStreamEx(streamName)
-    if err != nil {
-      panic(err)
-    }
+	var stream livepeer.CreateStreamResp
 
-    up := testers.NewHttpStreamer(gctx, true, "baseManifestID")
-    up.StartUpload(*fileArg, broadcasters[0]+"/live/"+stream.ID, stream.ID, 0, 0, *streamDuration, 0)
+	startStream := func() {
+		lapi.Init()
+		glog.Infof("Choosen server: %s", lapi.GetServer())
+		ingests, err := lapi.Ingest(false)
+		if err != nil {
+			panic(err)
+		}
+		glog.Infof("Got ingests: %+v", ingests)
+		broadcasters, err := lapi.Broadcasters()
+		if err != nil {
+			panic(err)
+		}
+		glog.Infof("Got broadcasters: %+v", broadcasters)
+		streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format(time.RFC3339Nano))
+		stream, err := lapi.CreateStreamEx(streamName)
+		if err != nil {
+			panic(err)
+		}
 
-    stats, err := up.Stats()
-    if err != nil {
-      panic(err)
-    }
+		up := testers.NewHTTPStreamer(gctx, true, "baseManifestID")
+		up.StartUpload(*fileArg, broadcasters[0]+"/live/"+stream.ID, stream.ID, 0, 0, *streamDuration, 0)
 
-    glog.Infof("Deleting stream %s: %v", stream.ID)
-    err = lapi.DeleteStream(stream.ID)
-    if err != nil {
-      glog.Errorf("Error deleting stream %s: %v", stream.ID, err)
-    }
+		stats, err := up.Stats()
+		if err != nil {
+			panic(err)
+		}
 
-    fmt.Println("========= Stats: =========")
-    fmt.Println(stats.FormatForConsole())
-    fmt.Println(stats.FormatErrorsForConsole())
+		glog.Infof("Deleting stream %s", stream.ID)
+		err = lapi.DeleteStream(stream.ID)
+		if err != nil {
+			glog.Errorf("Error deleting stream %s: %v", stream.ID, err)
+		}
 
-    streamDone <- true
-  }
+		fmt.Println("========= Stats: =========")
+		fmt.Println(stats.FormatForConsole())
+		fmt.Println(stats.FormatErrorsForConsole())
 
-  // setup signal trapping
-  signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
-  go func() {
-    <-sigs
-    fmt.Println("Got Ctrl-C, cancelling")
+		streamDone <- true
+	}
 
-    err = lapi.DeleteStream(stream.ID)
-    if err != nil {
-      glog.Errorf("Error deleting stream %s: %v", stream.ID, err)
-    }
-    fmt.Println("done")
+	// setup signal trapping
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+	go func() {
+		<-sigs
+		fmt.Println("Got Ctrl-C, cancelling")
 
-    done <- true
-  }()
+		err = lapi.DeleteStream(stream.ID)
+		if err != nil {
+			glog.Errorf("Error deleting stream %s: %v", stream.ID, err)
+		}
+		fmt.Println("done")
 
-  // run stream cycles until interupt or panic
-  for {
-    go startStream()
+		done <- true
+	}()
 
-    select {
-    case <-streamDone:
-      fmt.Println("Stream Cycle Complete")
-    case <-done:
-      os.Exit(model.ExitCode)
-    }
-  }
+	// run stream cycles until interupt or panic
+	for {
+		go startStream()
+
+		select {
+		case <-streamDone:
+			fmt.Println("Stream Cycle Complete")
+		case <-done:
+			os.Exit(model.ExitCode)
+		}
+	}
 }

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -1,0 +1,162 @@
+// a tool to run continuous streams to help monitor the platform
+package main
+
+import (
+  "context"
+  "flag"
+  "fmt"
+  "os"
+  "os/signal"
+  "runtime"
+  "syscall"
+  "time"
+  "github.com/golang/glog"
+  "github.com/livepeer/joy4/format"
+  "github.com/livepeer/stream-tester/apis/livepeer"
+  "github.com/livepeer/stream-tester/internal/metrics"
+  "github.com/livepeer/stream-tester/internal/testers"
+  "github.com/livepeer/stream-tester/internal/utils"
+  "github.com/livepeer/stream-tester/internal/server"
+  "github.com/livepeer/stream-tester/model"
+  "github.com/peterbourgon/ff/v2"
+)
+
+func init() {
+  format.RegisterAll()
+
+  // override glog's default -logtostderr flag
+  flag.Set("logtostderr", "true")
+
+  model.ProfilesNum = 1
+}
+
+func configureGlog() {
+
+}
+
+func main() {
+  var err error
+
+  fs := flag.NewFlagSet("stream-monitor", flag.ExitOnError)
+
+  apiServer := fs.String("api-server", "livepeer.com", "Server of the Livepeer API to be used")
+  apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used")
+  bind := fs.String("bind", "0.0.0.0:9090", "Address to bind metric server to")
+  fileArg := fs.String("file", "bbb_sunflower_1080p_30fps_normal_t02.mp4", "File to stream")
+  streamDuration := fs.Duration("stream-duration", 0, "How long to stream (0 to stream whole file)")
+  verbosity := fs.String("v", "", "Log verbosity.  {4|5|6}")
+  version := fs.Bool("version", false, "Print out the version")
+
+  _ = fs.String("config", "", "config file (optional)")
+  ff.Parse(
+    fs,
+    os.Args[1:],
+    ff.WithConfigFileFlag("config"),
+    ff.WithConfigFileParser(ff.PlainParser),
+    ff.WithEnvVarPrefix("STREAM_MONITOR"),
+  )
+
+  // configure glog
+  vFlag := flag.Lookup("v")
+  vFlag.Value.Set(*verbosity)
+  // supress errors in log output from glog
+  flag.CommandLine.Parse(nil)
+
+  hostName, _ := os.Hostname()
+
+  // Print startup
+  fmt.Println("StreamMonitor version: " + model.Version)
+  fmt.Printf("Compiler version: %s %s\n", runtime.Compiler, runtime.Version())
+  fmt.Printf("Hostname %s OS %s IPs %v\n", hostName, runtime.GOOS, utils.GetIPs())
+  fmt.Printf("Production: %v\n", model.Production)
+
+  gctx, _ := context.WithCancel(context.Background()) // to be used as global parent context, in the future
+
+  metrics.InitCensus(hostName, model.Version)
+
+  metricServer := server.NewMetricsServer()
+  go metricServer.Start(gctx, *bind)
+
+  if *version {
+    return
+  }
+
+  if _, err := os.Stat(*fileArg); os.IsNotExist(err) {
+    fmt.Printf("File '%s' does not exists", *fileArg)
+    os.Exit(1)
+  }
+
+  if *apiToken == "" {
+    glog.Fatalf("-api-token should be specified")
+  }
+
+  streamDone := make(chan bool, 1)
+  done := make(chan bool, 1)
+  sigs := make(chan os.Signal)
+  lapi := livepeer.NewLivepeer(*apiToken, *apiServer, nil)
+
+  var stream livepeer.CreateStreamResp
+
+  startStream := func() {
+    lapi.Init()
+    glog.Infof("Choosen server: %s", lapi.GetServer())
+    ingests, err := lapi.Ingest(false)
+    if err != nil {
+      panic(err)
+    }
+    glog.Infof("Got ingests: %+v", ingests)
+    broadcasters, err := lapi.Broadcasters()
+    if err != nil {
+      panic(err)
+    }
+    glog.Infof("Got broadcasters: %+v", broadcasters)
+    streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format(time.RFC3339Nano))
+    stream, err := lapi.CreateStreamEx(streamName)
+    if err != nil {
+      panic(err)
+    }
+
+    up := testers.NewHttpStreamer(gctx, true, "baseManifestID")
+    up.StartUpload(*fileArg, broadcasters[0]+"/live/"+stream.ID, stream.ID, 0, 0, *streamDuration, 0)
+
+    stats, err := up.Stats()
+    if err != nil {
+      panic(err)
+    }
+
+    glog.Infof("Deleting stream %s: %v", stream.ID)
+    err = lapi.DeleteStream(stream.ID)
+    if err != nil {
+      glog.Errorf("Error deleting stream %s: %v", stream.ID, err)
+    }
+
+    fmt.Println("========= Stats: =========")
+    fmt.Println(stats.FormatForConsole())
+    fmt.Println(stats.FormatErrorsForConsole())
+
+    streamDone <- true
+  }
+
+  for {
+    go startStream()
+    <-streamDone
+  }
+
+  signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+
+  go func() {
+    <-sigs
+    fmt.Println("Got Ctrl-C, cancelling")
+
+    err = lapi.DeleteStream(stream.ID)
+    if err != nil {
+      glog.Errorf("Error deleting stream %s: %v", stream.ID, err)
+    }
+    fmt.Println("done")
+
+    done <- true
+  }()
+
+  <-done
+  os.Exit(model.ExitCode)
+}

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -30,10 +30,6 @@ func init() {
   model.ProfilesNum = 1
 }
 
-func configureGlog() {
-
-}
-
 func main() {
   var err error
 

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -133,13 +133,8 @@ func main() {
     streamDone <- true
   }
 
-  for {
-    go startStream()
-    <-streamDone
-  }
-
+  // setup signal trapping
   signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
-
   go func() {
     <-sigs
     fmt.Println("Got Ctrl-C, cancelling")
@@ -152,6 +147,11 @@ func main() {
 
     done <- true
   }()
+
+  for {
+    go startStream()
+    <-streamDone
+  }
 
   <-done
   os.Exit(model.ExitCode)

--- a/cmd/stream-monitor/stream-monitor.go
+++ b/cmd/stream-monitor/stream-monitor.go
@@ -154,7 +154,7 @@ func main() {
 
     select {
     case <-streamDone:
-        fmt.Println("Stream Cycle Complete")
+      fmt.Println("Stream Cycle Complete")
     case <-done:
       os.Exit(model.ExitCode)
     }

--- a/cmd/streamtester/streamtester.go
+++ b/cmd/streamtester/streamtester.go
@@ -309,7 +309,7 @@ func main() {
 			if len(bds) == 0 {
 				glog.Fatal("Got empty list of broadcasterf from Livepeer API")
 			}
-			up := testers.NewHTTPtreamer(gctx, true, "baseManifestID")
+			up := testers.NewHttpStreamer(gctx, true, "baseManifestID")
 			up.StartUpload(fn, bds[0]+"/live/"+stream.ID, stream.ID, 0, 0, streamDuration, 0)
 			stats, err := up.Stats()
 			if err != nil {

--- a/cmd/streamtester/streamtester.go
+++ b/cmd/streamtester/streamtester.go
@@ -309,7 +309,7 @@ func main() {
 			if len(bds) == 0 {
 				glog.Fatal("Got empty list of broadcasterf from Livepeer API")
 			}
-			up := testers.NewHttpStreamer(gctx, true, "baseManifestID")
+			up := testers.NewHTTPStreamer(gctx, true, "baseManifestID")
 			up.StartUpload(fn, bds[0]+"/live/"+stream.ID, stream.ID, 0, 0, streamDuration, 0)
 			stats, err := up.Stats()
 			if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  stream-monitor:
+    build: .
+    command:
+      - -api-server
+      - ${API_SERVER}
+      - -api-token
+      - ${API_TOKEN}
+      - -stream-duration
+      - 30s
+      - -bind
+      - "0.0.0.0:9090"
+      - -v
+      - "10"
+    entrypoint:
+      - /root/stream-monitor
+    ports:
+      - "9090:9090"
+
+  # useful for interacting with the build context
+  builder:
+    build:
+      context: .
+      target: builder
+    command: ash
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./:/root

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/stream-tester/internal/metrics"
+)
+
+type MetricsServer struct {
+}
+
+// NewStreamerServer creates new MetricsServer
+func NewMetricsServer() *MetricsServer {
+	return &MetricsServer{}
+}
+
+// Starts metric server
+// blocks until exit
+func (s *MetricsServer) Start(ctx context.Context, bindAddr string) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", metrics.Exporter)
+
+	srv := &http.Server{
+		Addr:    bindAddr,
+		Handler: mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+		c, _ := context.WithTimeout(context.Background(), time.Second)
+		glog.Infof("Shutting down metrics server")
+		srv.Shutdown(c)
+	}()
+
+	glog.Info("Metrics server listening on ", bindAddr)
+	srv.ListenAndServe()
+}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -9,7 +9,7 @@ import (
 	"github.com/livepeer/stream-tester/internal/metrics"
 )
 
-// MetricsServer creates new MetricsServer
+// MetricsServer object
 type MetricsServer struct {
 }
 
@@ -31,7 +31,8 @@ func (s *MetricsServer) Start(ctx context.Context, bindAddr string) {
 
 	go func() {
 		<-ctx.Done()
-		c, _ := context.WithTimeout(context.Background(), time.Second)
+		c, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
 		glog.Infof("Shutting down metrics server")
 		srv.Shutdown(c)
 	}()

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,12 +1,12 @@
 package server
 
 import (
-	"context"
-	"net/http"
-	"time"
+  "context"
+  "net/http"
+  "time"
 
-	"github.com/golang/glog"
-	"github.com/livepeer/stream-tester/internal/metrics"
+  "github.com/golang/glog"
+  "github.com/livepeer/stream-tester/internal/metrics"
 )
 
 type MetricsServer struct {
@@ -14,27 +14,27 @@ type MetricsServer struct {
 
 // NewStreamerServer creates new MetricsServer
 func NewMetricsServer() *MetricsServer {
-	return &MetricsServer{}
+  return &MetricsServer{}
 }
 
 // Starts metric server
 // blocks until exit
 func (s *MetricsServer) Start(ctx context.Context, bindAddr string) {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", metrics.Exporter)
+  mux := http.NewServeMux()
+  mux.Handle("/metrics", metrics.Exporter)
 
-	srv := &http.Server{
-		Addr:    bindAddr,
-		Handler: mux,
-	}
+  srv := &http.Server{
+    Addr:    bindAddr,
+    Handler: mux,
+  }
 
-	go func() {
-		<-ctx.Done()
-		c, _ := context.WithTimeout(context.Background(), time.Second)
-		glog.Infof("Shutting down metrics server")
-		srv.Shutdown(c)
-	}()
+  go func() {
+    <-ctx.Done()
+    c, _ := context.WithTimeout(context.Background(), time.Second)
+    glog.Infof("Shutting down metrics server")
+    srv.Shutdown(c)
+  }()
 
-	glog.Info("Metrics server listening on ", bindAddr)
-	srv.ListenAndServe()
+  glog.Info("Metrics server listening on ", bindAddr)
+  srv.ListenAndServe()
 }

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,40 +1,41 @@
 package server
 
 import (
-  "context"
-  "net/http"
-  "time"
+	"context"
+	"net/http"
+	"time"
 
-  "github.com/golang/glog"
-  "github.com/livepeer/stream-tester/internal/metrics"
+	"github.com/golang/glog"
+	"github.com/livepeer/stream-tester/internal/metrics"
 )
 
+// MetricsServer creates new MetricsServer
 type MetricsServer struct {
 }
 
 // NewMetricsServer creates new MetricsServer
 func NewMetricsServer() *MetricsServer {
-  return &MetricsServer{}
+	return &MetricsServer{}
 }
 
-// Starts metric server
+// Start starts the metric server
 // blocks until exit
 func (s *MetricsServer) Start(ctx context.Context, bindAddr string) {
-  mux := http.NewServeMux()
-  mux.Handle("/metrics", metrics.Exporter)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", metrics.Exporter)
 
-  srv := &http.Server{
-    Addr:    bindAddr,
-    Handler: mux,
-  }
+	srv := &http.Server{
+		Addr:    bindAddr,
+		Handler: mux,
+	}
 
-  go func() {
-    <-ctx.Done()
-    c, _ := context.WithTimeout(context.Background(), time.Second)
-    glog.Infof("Shutting down metrics server")
-    srv.Shutdown(c)
-  }()
+	go func() {
+		<-ctx.Done()
+		c, _ := context.WithTimeout(context.Background(), time.Second)
+		glog.Infof("Shutting down metrics server")
+		srv.Shutdown(c)
+	}()
 
-  glog.Info("Metrics server listening on ", bindAddr)
-  srv.ListenAndServe()
+	glog.Info("Metrics server listening on ", bindAddr)
+	srv.ListenAndServe()
 }

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -12,7 +12,7 @@ import (
 type MetricsServer struct {
 }
 
-// NewStreamerServer creates new MetricsServer
+// NewMetricsServer creates new MetricsServer
 func NewMetricsServer() *MetricsServer {
   return &MetricsServer{}
 }

--- a/internal/testers/http_load_tester.go
+++ b/internal/testers/http_load_tester.go
@@ -148,7 +148,7 @@ func (hlt *HTTPLoadTester) startStreams(baseManifestID, sourceFileName string, r
 		// 	bar = uiprogress.AddBar(totalSegments).AppendCompleted().PrependElapsed()
 		// }
 
-		up := NewHTTPtreamer(hlt.ctx, measureLatency, baseManifestID)
+		up := NewHttpStreamer(hlt.ctx, measureLatency, baseManifestID)
 		wg.Add(1)
 		go func() {
 			up.StartUpload(sourceFileName, httpIngestURL, manifestID, 0, waitForTarget, stopAfter, hlt.skipFirst)

--- a/internal/testers/http_load_tester.go
+++ b/internal/testers/http_load_tester.go
@@ -148,7 +148,7 @@ func (hlt *HTTPLoadTester) startStreams(baseManifestID, sourceFileName string, r
 		// 	bar = uiprogress.AddBar(totalSegments).AppendCompleted().PrependElapsed()
 		// }
 
-		up := NewHttpStreamer(hlt.ctx, measureLatency, baseManifestID)
+		up := NewHTTPStreamer(hlt.ctx, measureLatency, baseManifestID)
 		wg.Add(1)
 		go func() {
 			up.StartUpload(sourceFileName, httpIngestURL, manifestID, 0, waitForTarget, stopAfter, hlt.skipFirst)

--- a/internal/testers/http_streamer.go
+++ b/internal/testers/http_streamer.go
@@ -60,8 +60,8 @@ type httpStats struct {
 	started           time.Time
 }
 
-// NewHttpStreamer ...
-func NewHttpStreamer(ctx context.Context, saveLatencies bool, baseManifestID string) *httpStreamer {
+// NewHTTPStreamer ...
+func NewHTTPStreamer(ctx context.Context, saveLatencies bool, baseManifestID string) *httpStreamer {
 	hs := &httpStreamer{ctx: ctx, saveLatencies: saveLatencies, baseManifestID: baseManifestID}
 	hs.dstats.errors = make(map[string]int)
 	return hs

--- a/internal/testers/http_streamer.go
+++ b/internal/testers/http_streamer.go
@@ -60,8 +60,8 @@ type httpStats struct {
 	started           time.Time
 }
 
-// NewHTTPtreamer ...
-func NewHTTPtreamer(ctx context.Context, saveLatencies bool, baseManifestID string) *httpStreamer {
+// NewHttpStreamer ...
+func NewHttpStreamer(ctx context.Context, saveLatencies bool, baseManifestID string) *httpStreamer {
 	hs := &httpStreamer{ctx: ctx, saveLatencies: saveLatencies, baseManifestID: baseManifestID}
 	hs.dstats.errors = make(map[string]int)
 	return hs


### PR DESCRIPTION
Stream a target file to http ingest in cycles and surface metrics on these stream-cycles via a prom exporter.