### PR TITLE
change consul parameters

### DIFF
--- a/Dockerfile.load-test
+++ b/Dockerfile.load-test
@@ -1,0 +1,57 @@
+FROM golang:1.13-stretch as builder
+
+# RUN apk add --no-cache git
+
+WORKDIR /root
+RUN wget https://storage.googleapis.com/lp_testharness_assets/official_test_source_2s_keys_24pfs.mp4
+# RUN wget https://storage.googleapis.com/lp_testharness_assets/official_test_source_2s_keys_24pfs_3min.mp4
+# RUN wget https://storage.googleapis.com/lp_testharness_assets/bbb_sunflower_1080p_30fps_normal_t02.mp4
+# RUN wget https://storage.googleapis.com/lp_testharness_assets/bbb_sunflower_1080p_30fps_normal_2min.mp4
+
+ENV GOFLAGS "-mod=readonly"
+ARG version
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go mod download
+
+COPY cmd cmd 
+COPY internal internal
+COPY model model
+COPY messenger messenger
+COPY apis apis
+
+RUN echo $version
+
+RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/streamtester/streamtester.go
+RUN go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/loadtester/loadtester.go
+
+
+FROM debian:stretch-slim
+
+WORKDIR /root
+# RUN apt update && apt install -y  ca-certificates jq libgnutls30 && apt clean
+RUN apt update && apt install -y ca-certificates && apt clean
+
+COPY --from=builder /root/official_test_source_2s_keys_24pfs.mp4 official_test_source_2s_keys_24pfs.mp4
+# COPY --from=builder /root/official_test_source_2s_keys_24pfs_3min.mp4 official_test_source_2s_keys_24pfs_3min.mp4
+# COPY --from=builder /root/bbb_sunflower_1080p_30fps_normal_t02.mp4 bbb_sunflower_1080p_30fps_normal_t02.mp4
+# COPY --from=builder /root/bbb_sunflower_1080p_30fps_normal_2min.mp4 bbb_sunflower_1080p_30fps_normal_2min.mp4
+COPY --from=builder /root/streamtester streamtester
+COPY --from=builder /root/loadtester loadtester
+
+RUN apt-get update && apt-get install -y curl
+
+# RUN /root/loadtester -help
+
+# CMD /bin/bash -c 'curl -L https://eric-test-livepeer.s3.amazonaws.com/bbbx3_720.mp4 -o $(hostname).mp4 && exec /root/streamtester -host=chi-origin.livepeer.live -media-host=chi.livepeer.live -media=443 -profiles=3 -sim=100 -repeat=999 $(hostname).mp4'
+CMD /bin/bash -c 'curl -L https://eric-test-livepeer.s3.amazonaws.com/bbbx3_720.mp4 -o $(hostname).mp4 && \
+  exec /root/loadtester -api-token 29e0c327-eb75-4c42-a598-e5a4737f9d67 -api-server iad.livepeer.com -file $(hostname).mp4 -profiles 4 -sim 100 -http-ingest=true'
+
+# CMD /bin/bash -c 'mv official_test_source_2s_keys_24pfs.mp4 $(hostname).mp4 && exec /root/streamtester -host=chi-origin.livepeer.live -media-host=chi.livepeer.live -media=443 -profiles=3 -sim=71 -repeat=999 $(hostname).mp4'
+# docker build -t livepeer/streamtester:latest .
+# docker build -t livepeer/streamtester:latest --build-arg version=$(git describe --dirty) .
+# docker push livepeer/streamtester:latest
+# docker build -t livepeer/streamtester:test .
+# docker push livepeer/streamtester:test

--- a/cmd/mist-api-connector/mist-api-connector.go
+++ b/cmd/mist-api-connector/mist-api-connector.go
@@ -36,7 +36,8 @@ func main() {
 	apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used by the Mist server")
 	apiServer := fs.String("api-server", livepeer.ACServer, "Livepeer API server to use")
 	consulURI := fs.String("consul", "", "Base URL to access Consul (for example: http://localhost:8500)")
-	mistServiceNameInTraefik := fs.String("mist-service-name", "", "Name of the service for this Mist inside Traefik (to be put in Consul)")
+	playbackDomain := fs.String("playback-domain", "", "domain to create consul routes for (ex: playback.livepeer.live)")
+	mistURL := fs.String("mist-url", "", "external URL of this Mist instance (to be put in Consul) (ex: https://mist-server-0.livepeer.live)")
 	_ = fs.String("config", "", "config file (optional)")
 
 	ff.Parse(fs, os.Args[1:],
@@ -70,7 +71,7 @@ func main() {
 			glog.Fatalf("Error parsing Consul URL: %v", err)
 		}
 	}
-	mc := mistapiconnector.NewMac(*mistHost, mapi, lapi, *balancerHost, false, consulURL, *mistServiceNameInTraefik, *sendAudio)
+	mc := mistapiconnector.NewMac(*mistHost, mapi, lapi, *balancerHost, false, consulURL, *playbackDomain, *mistURL, *sendAudio)
 	if err := mc.SetupTriggers(*ownURI); err != nil {
 		glog.Fatal(err)
 	}

--- a/cmd/mist-api-connector/mist-api-connector.go
+++ b/cmd/mist-api-connector/mist-api-connector.go
@@ -37,7 +37,7 @@ func main() {
 	apiServer := fs.String("api-server", livepeer.ACServer, "Livepeer API server to use")
 	consulURI := fs.String("consul", "", "Base URL to access Consul (for example: http://localhost:8500)")
 	playbackDomain := fs.String("playback-domain", "", "domain to create consul routes for (ex: playback.livepeer.live)")
-	mistURL := fs.String("mist-url", "", "external URL of this Mist instance (to be put in Consul) (ex: https://mist-server-0.livepeer.live)")
+	mistURL := fs.String("consul-mist-url", "", "external URL of this Mist instance (to be put in Consul) (ex: https://mist-server-0.livepeer.live)")
 	_ = fs.String("config", "", "config file (optional)")
 
 	ff.Parse(fs, os.Args[1:],

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -319,6 +319,7 @@ func (mc *mac) handleDefaultStreamTrigger(w http.ResponseWriter, r *http.Request
 				traefikKeyPathRouters+streamKey+"/service",
 				streamKey,
 				traefikKeyPathServices+streamKey+"/loadbalancer/servers/0/url",
+				mc.mistURL,
 			)
 			if err != nil {
 				glog.Errorf("Error creating Traefik rule err=%v", err)


### PR DESCRIPTION
Instead of hitting a service, we can create our own custom service record and forward traffic wherever we want. So this sets us up to route `/hls/{playbackId}` to `https://mdw-staging-mist-server-0.livepeer.monster`, which is ready for global replication on ingest URLs.