### PR TITLE
orch-tester: random sample segments

### DIFF
--- a/internal/testers/azure.go
+++ b/internal/testers/azure.go
@@ -63,7 +63,7 @@ func isNoCodecError(verr error) bool {
 	return errors.Is(verr, jerrors.ErrNoAudioInfoFound) || errors.Is(verr, jerrors.ErrNoVideoInfoFound)
 }
 
-func saveToExternalStorage(fileName string, data []byte) (string, string, error) {
+func SaveToExternalStorage(fileName string, data []byte) (string, string, error) {
 	if azure == nil && Bucket == "" {
 		return "", "", nil
 	}

--- a/internal/testers/m3utester2.go
+++ b/internal/testers/m3utester2.go
@@ -1117,7 +1117,7 @@ func downloadSegment(task *downloadTask, res chan *downloadResult) {
 				glog.V(model.DEBUG).Infof("==============>>>>>>>>>>>>>  Saving segment %s", sn)
 				ioutil.WriteFile(sn, b, 0644)
 				sid := strconv.FormatInt(time.Now().Unix(), 10)
-				if savedName, service, serr := saveToExternalStorage(sid+"_"+task.url, b); serr != nil {
+				if savedName, service, serr := SaveToExternalStorage(sid+"_"+task.url, b); serr != nil {
 					messenger.SendFatalMessage(fmt.Sprintf("Failure to save segment to %s %v", service, serr))
 				} else {
 					messenger.SendMessage(fmt.Sprintf("Segment %s (which can't be parsed) saved to %s %s", task.url, service, savedName))

--- a/internal/testers/mediadownloader.go
+++ b/internal/testers/mediadownloader.go
@@ -240,7 +240,7 @@ func (md *mediaDownloader) downloadSegment(task *downloadTask, res chan download
 					task.seqNo, randName())
 				err = ioutil.WriteFile(fname, b, 0644)
 				glog.Infof("Wrote bad segment to local file '%s' (err=%v)", fname, err)
-				if extURL, service, err := saveToExternalStorage(fname, b); err != nil {
+				if extURL, service, err := SaveToExternalStorage(fname, b); err != nil {
 					glog.Infof("Failed saving bad segment %s to %s err=%v", fname, service, err)
 				} else {
 					messenger.SendFatalMessage(fmt.Sprintf("Saved bad segment to %s url=%s verr=%v", service, extURL, verr))


### PR DESCRIPTION
If enabled using `-randomsample=true` orch-tester will randomly sample a segment and write it to the provided GCP bucket (`-gsbucket` and  `- gskey`) 

1. For each orchestrator pick a random video profile and seqNo 
2. Start the stream 
3. As the stream is started start fetching the target segment from the broadcaster
4. When the stream finishes stop fetching segments from the broadcaster
5. If no segment is found query the entire last known playlist for the stream's manifest ID
6. from that playlist randomly get a segment 