### PR TITLE
mist-api-connector: route traffic with 'video+' correctly

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -21,6 +21,7 @@ import (
 
 const streamPlaybackPrefix = "playback_"
 const traefikRuleTemplate = "HostRegexp(`%s`) && PathPrefix(`/hls/%s/`)"
+const traefikRuleTemplateDouble = "HostRegexp(`%s`) && (PathPrefix(`/hls/%s/`) || PathPrefix(`/hls/%s/`))"
 const traefikKeyPathRouters = `traefik/http/routers/`
 const traefikKeyPathServices = `traefik/http/services/`
 const traefikKeyPathMiddlewares = `traefik/http/middlewares/`
@@ -389,7 +390,7 @@ func (mc *mac) handleDefaultStreamTrigger(w http.ResponseWriter, r *http.Request
 				err = consul.PutKeysWithCurrentTime(
 					mc.consulURL,
 					traefikKeyPathRouters+playbackID+"/rule",
-					fmt.Sprintf(traefikRuleTemplate, mc.playbackDomain, stream.PlaybackID),
+					fmt.Sprintf(traefikRuleTemplateDouble, mc.playbackDomain, stream.PlaybackID, wildcardPlaybackID),
 					traefikKeyPathRouters+playbackID+"/service",
 					serviceName,
 					traefikKeyPathRouters+playbackID+"/middlewares/0",
@@ -399,6 +400,8 @@ func (mc *mac) handleDefaultStreamTrigger(w http.ResponseWriter, r *http.Request
 
 					traefikKeyPathMiddlewares+playbackID+"-1/stripprefix/prefixes/0",
 					`/hls/`+stream.PlaybackID,
+					traefikKeyPathMiddlewares+playbackID+"-1/stripprefix/prefixes/1",
+					`/hls/`+wildcardPlaybackID,
 					traefikKeyPathMiddlewares+playbackID+"-2/addprefix/prefix",
 					`/hls/`+wildcardPlaybackID,
 


### PR DESCRIPTION
When I ask Mist to return absolute URLs, it returns them like this: 
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:8
#EXT-X-MEDIA-SEQUENCE:7
#EXTINF:6.333000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/27067_33400.ts
#EXTINF:6.000000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/33400_39400.ts
#EXTINF:6.334000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/39400_45734.ts
#EXTINF:6.000000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/45734_51734.ts
#EXTINF:6.333000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/51734_58067.ts
#EXTINF:5.733000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/58067_63800.ts
#EXTINF:5.634000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/63800_69434.ts
#EXTINF:6.033000,
https://mdw-cdn.livepeer.monster/hls/video+9e60a32fv9h42mvd/4_1/69434_75467.ts
```
This change makes us handle incoming traffic at the `video+` versions of these URLs too.