### PR TITLE
mist-api-connector: Recover etcd session when lease is lost

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -687,7 +687,7 @@ func newEtcdSession(etcdClient *clientv3.Client) (*concurrency.Session, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mist-api-connector: Error creating etcd session err=%w", err)
 	}
-	glog.Info("etcd got lease %d", sess.Lease())
+	glog.Infof("etcd got lease %d", sess.Lease())
 	return sess, nil
 }
 

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -690,11 +690,7 @@ func (mc *mac) recoverEtcdSessionOnce() error {
 }
 
 func newEtcdSession(etcdClient *clientv3.Client) (*concurrency.Session, error) {
-	ctx, cancel := context.WithTimeout(etcdClient.Ctx(), etcdDialTimeout)
-	defer cancel()
-	sess, err := concurrency.NewSession(etcdClient,
-		concurrency.WithTTL(etcdSessionTTL),
-		concurrency.WithContext(ctx))
+	sess, err := concurrency.NewSession(etcdClient, concurrency.WithTTL(etcdSessionTTL))
 	if err != nil {
 		return nil, fmt.Errorf("mist-api-connector: Error creating etcd session err=%w", err)
 	}

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -636,7 +636,7 @@ func (mc *mac) recoverSessionLoop() {
 		cancel()
 
 		if err != nil && clientCtx.Err() == nil {
-			glog.Error("Shutting down due to unrecoverable etcd session. err=%q. ", err)
+			glog.Errorf("Shutting down due to unrecoverable etcd session. err=%q.", err)
 			mc.shutdown()
 			return
 		}

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -691,7 +691,11 @@ func (mc *mac) recoverEtcdSessionOnce() error {
 }
 
 func newEtcdSession(etcdClient *clientv3.Client) (*concurrency.Session, error) {
-	sess, err := concurrency.NewSession(etcdClient, concurrency.WithTTL(etcdSessionTTL))
+	ctx, cancel := context.WithTimeout(etcdClient.Ctx(), etcdDialTimeout)
+	defer cancel()
+	sess, err := concurrency.NewSession(etcdClient,
+		concurrency.WithTTL(etcdSessionTTL),
+		concurrency.WithContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("mist-api-connector: Error creating etcd session err=%w", err)
 	}

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -644,8 +644,7 @@ func (mc *mac) recoverSessionLoop() {
 		cancel()
 
 		if err != nil && clientCtx.Err() == nil {
-			glog.Errorf("Shutting down due to unrecoverable etcd session. err=%q.", err)
-			mc.shutdown()
+			glog.Errorf("mist-api-connector: unrecoverable etcd session. err=%q.", err)
 			return
 		}
 	}

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -129,6 +129,13 @@ func NewMac(mistHost string, mapi *mist.API, lapi *livepeer.API, balancerHost st
 			err = fmt.Errorf("mist-api-connector: Error connecting etcd err=%w", err)
 			return nil, err
 		}
+		ctx, cancel := context.WithTimeout(context.Background(), etcdDialTimeout)
+		err = cli.Sync(ctx)
+		cancel()
+		if err != nil {
+			err = fmt.Errorf("mist-api-connector: Error syncing etcd endpoints err=%w", err)
+			return nil, err
+		}
 		sess, err = newEtcdSession(cli)
 		if err != nil {
 			return nil, err

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -509,6 +509,7 @@ func (mc *mac) handleDefaultStreamTrigger(w http.ResponseWriter, r *http.Request
 			glog.Errorf("Error creating Traefik rule err=%v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte("false"))
+			return
 		}
 	}
 	if mc.useEtcd {
@@ -556,6 +557,7 @@ func (mc *mac) handleDefaultStreamTrigger(w http.ResponseWriter, r *http.Request
 			glog.Errorf("Error creating etcd Traefik rule for playbackID=%s streamID=%s err=%v", stream.PlaybackID, stream.ID, err)
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte("false"))
+			return
 		}
 	}
 	w.Write([]byte(responseURL))

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -630,6 +630,7 @@ func (mc *mac) recoverSessionLoop() {
 			return
 		case <-mc.etcdSession.Done():
 		}
+		glog.Infof("etcd session with lease=%d is lost, trying to recover", mc.etcdSession.Lease())
 
 		ctx, cancel := context.WithTimeout(clientCtx, etcdSessionRecoverTimeout)
 		err := mc.recoverEtcdSession(ctx)

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -690,8 +690,10 @@ func (mc *mac) recoverEtcdSessionOnce() error {
 }
 
 func newEtcdSession(etcdClient *clientv3.Client) (*concurrency.Session, error) {
+	glog.Infof("Starting new etcd session ttl=%d", etcdSessionTTL)
 	sess, err := concurrency.NewSession(etcdClient, concurrency.WithTTL(etcdSessionTTL))
 	if err != nil {
+		glog.Errorf("Failed to start etcd session err=%q", err)
 		return nil, fmt.Errorf("mist-api-connector: Error creating etcd session err=%w", err)
 	}
 	glog.Infof("etcd got lease %d", sess.Lease())


### PR DESCRIPTION
This is a proposal for the `etcd` write failure we are still getting once and a while in production.

I believe it will be necessary even after we change the `etcd` endpoints to contain all members of 
the cluster, since `mist-api-connector` itself is already using the `AutoSyncInterval` option of
the client, which means that it will only stay attached to a single server on the first 5 minutes 
after startup. After that, the client will grab all endpoints from the cluster automatically.

So we are still losing the session sometimes for some reason, and I believe having a recovering
mechanism like this will fix any issues from that. Also added a last resort mechanic of shutting 
down the server in case we can't recover the session after 2 minutes, which feels like a time we
would be restarting the mist servers ourselves anyway. 
