### PR TITLE
mist-api-connector: Implement healthcheck for k8s probes

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -1039,12 +1039,30 @@ func (mc *mac) createMistStream(streamName string, stream *livepeer.CreateStream
 	return err
 }
 
+func (mc *mac) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
+	if !mc.isEtcdSessionHealthy() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (mc *mac) isEtcdSessionHealthy() bool {
+	select {
+	case <-mc.etcdSession.Done():
+		return false
+	default:
+		return true
+	}
+}
+
 func (mc *mac) webServerHandlers() *http.ServeMux {
 	mux := http.NewServeMux()
 	utils.AddPProfHandlers(mux)
 	// mux.Handle("/metrics", utils.InitPrometheusExporter("mistconnector"))
 	mux.Handle("/metrics", metrics.Exporter)
 
+	mux.HandleFunc("/_healthz", mc.handleHealthcheck)
 	mux.HandleFunc("/", mc.handleDefaultStreamTrigger)
 	return mux
 }

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -931,6 +931,9 @@ func (mc *mac) deleteEtcdKeys(playbackID string) {
 }
 
 func (mc *mac) recoverSessionLoop() {
+	if mc.etcdClient == nil {
+		return
+	}
 	clientCtx := mc.etcdClient.Ctx()
 	for clientCtx.Err() == nil {
 		select {
@@ -1048,6 +1051,9 @@ func (mc *mac) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func (mc *mac) isEtcdSessionHealthy() bool {
+	if mc.etcdSession == nil {
+		return true
+	}
 	select {
 	case <-mc.etcdSession.Done():
 		return false


### PR DESCRIPTION
This is first to implement a healthcheck API in mapic server, to allow creating a readiness probe in k8s.

On the way to that also found out that we have frequent restarts (up to 2) on `mist-api-connector` because
it tries to connect too fast to Mist, before it is ready. So I implemented a little retry logic on startup so we 
give some time for Mist server to be available before giving up and restarting the container.

Some idea I had for the future is being able to configure mapic containers with a `restartPolicy: never`, so
we can make sure that the mapic container never restarts. Those would create inconsistencies between its
state in etcd/memory with what is actually happening on mist side, so we probably want some datadog alerts
in case any of those happen (either mist or mapic)