### PR TITLE
mist-api-connector: Check mist-api on healthcheck

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -1047,6 +1047,11 @@ func (mc *mac) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
+	if config, err := mc.mapi.GetConfig(); err != nil || config == nil {
+		glog.Errorf("Error getting mist config on healthcheck. err=%q", err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Do so by calling GetConfig API which felt lightweight enough
to be called frequently (every ~5s or so)