### PR TITLE
mist-api-connector: Rename (rtmp)push(target) to multistream(target)

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -84,6 +84,7 @@ type (
 		pushStartEmitted bool
 		pushStopped      bool
 		target           *livepeer.MultistreamTarget
+		profile          string
 	}
 
 	streamInfo struct {
@@ -756,8 +757,9 @@ func (mc *mac) emitWebhookEvent(info *streamInfo, pushInfo *pushStatus, event st
 		StreamID:  info.stream.ID,
 		Payload: map[string]interface{}{
 			"target": map[string]interface{}{
-				"id":   pushInfo.target.ID,
-				"name": pushInfo.target.Name,
+				"id":      pushInfo.target.ID,
+				"name":    pushInfo.target.Name,
+				"profile": pushInfo.profile,
 			},
 		},
 	}
@@ -1223,7 +1225,7 @@ func (mc *mac) startMultistream(wildcardPlaybackID, playbackID string, info *str
 			// Inject ?video=~widthxheight to send the correct rendition
 			selectorURL := fmt.Sprintf("%s%svideo=%s&audio=maxbps", target.URL, join, videoSelector)
 			info.mu.Lock()
-			info.pushStatus[selectorURL] = &pushStatus{target: target}
+			info.pushStatus[selectorURL] = &pushStatus{target: target, profile: targetRef.Profile}
 
 			err = mc.mapi.StartPush(wildcardPlaybackID, selectorURL)
 			if err != nil {

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -754,7 +754,12 @@ func (mc *mac) emitWebhookEvent(info *streamInfo, pushInfo *pushStatus, event st
 		CreatedAt: time.Now().UnixNano() / int64(time.Millisecond),
 		UserID:    info.stream.UserID,
 		StreamID:  info.stream.ID,
-		Payload:   map[string]interface{}{"targetUrl": pushInfo.target.URL},
+		Payload: map[string]interface{}{
+			"target": map[string]interface{}{
+				"id":   pushInfo.target.ID,
+				"name": pushInfo.target.Name,
+			},
+		},
 	}
 	glog.Infof("Publishing amqp message to exchange=%s msg=%+v", EXCHANGE_NAME, wm)
 	err := mc.producer.Publish(mc.ctx, "events.multistream", &wm, true)


### PR DESCRIPTION
Following the [rename on the API](https://github.com/livepeer/livepeer-com/pull/557), this does the same renames
on the current only known client for the feature.