### PR TITLE
CI: Publish version tags with all images

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,20 +17,30 @@ jobs:
       env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD 
+      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - name: Get git tag
+      id: git_tag
+      run: |
+        echo ::set-output name=VERSION::$(git describe --tag --dirty)
+    - name: Get build tag
+      id: build_tag
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
     - name: Build the Docker image
-      # run: docker build . --file Dockerfile --tag livepeer/streamtester:$(date +%s)
-      run: docker build . --file Dockerfile --tag livepeer/streamtester:latest --build-arg version=$(git describe --dirty)
-    - name: Get tag name
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: docker build . --file Dockerfile --tag livepeer/streamtester:latest --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+
+    - name: Push Docker Container to Registry
+      run: docker push livepeer/streamtester:latest
     - name: Tag version
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        docker tag livepeer/streamtester:latest livepeer/streamtester:${{ steps.get_version.outputs.VERSION }}
-        docker push livepeer/streamtester:${{ steps.get_version.outputs.VERSION }}
+        docker tag livepeer/streamtester:latest livepeer/streamtester:${{ steps.build_tag.outputs.VERSION }}
+    - name: Tag git version
+      run: |
+        docker tag livepeer/streamtester:latest livepeer/streamtester:${{ steps.git_tag.outputs.VERSION }}
     - name: Push Docker Container to Registry
-      run: docker push livepeer/streamtester:latest
+      run: |
+        docker push --all-tags livepeer/streamtester
 
     - name: Notify that new build has been uploaded
       run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -27,8 +27,8 @@ jobs:
 
     - name: Build the Docker image
       run: |
-        TAGS=(${{ steps.tags.outputs.tags }})
-        docker build . --file Dockerfile ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
+        TAGS='${{ steps.tags.outputs.tags }}'
+        docker build . --file Dockerfile $(printf ' -t livepeer/streamtester:%s' $TAGS) --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,29 +18,21 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - name: Get git tag
-      id: git_tag
-      run: |
-        echo ::set-output name=VERSION::$(git describe --tag --dirty)
-    - name: Get build tag
-      id: build_tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+    - name: Tags
+      id: tags
+      uses: livepeer/action-gh-release-tags@v0
 
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag livepeer/streamtester:latest --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+      run: |
+        TAGS=(latest ${{ steps.tags.outputs.tags }})
+        docker build . --file Dockerfile ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
-      run: docker push livepeer/streamtester:latest
-    - name: Tag version
-      if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        docker tag livepeer/streamtester:latest livepeer/streamtester:${{ steps.build_tag.outputs.VERSION }}
-    - name: Tag git version
-      run: |
-        docker tag livepeer/streamtester:latest livepeer/streamtester:${{ steps.git_tag.outputs.VERSION }}
-    - name: Push Docker Container to Registry
-      run: |
-        docker push --all-tags livepeer/streamtester
+        for TAG in latest ${{ steps.tags.outputs.tags }}; do
+          docker push livepeer/streamtester:$TAG
+        done
 
     - name: Notify that new build has been uploaded
       run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -22,15 +22,17 @@ jobs:
     - name: Tags
       id: tags
       uses: livepeer/action-gh-release-tags@v0
+      with:
+        force-latest: true
 
     - name: Build the Docker image
       run: |
-        TAGS=(latest ${{ steps.tags.outputs.tags }})
+        TAGS=(${{ steps.tags.outputs.tags }})
         docker build . --file Dockerfile ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |
-        for TAG in latest ${{ steps.tags.outputs.tags }}; do
+        for TAG in ${{ steps.tags.outputs.tags }}; do
           docker push livepeer/streamtester:$TAG
         done
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 name: Publish new Release
 #on: [push]
 on:
-  push:  
+  push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 jobs:
@@ -9,10 +9,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
 
     - name: Check out code into the Go module directory
@@ -55,10 +55,10 @@ jobs:
     needs: create_release
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.15
       id: go
 
     - name: Check out code into the Go module directory
@@ -76,7 +76,7 @@ jobs:
         make mapi
         make connector
         make loadtester
-        make recordtester 
+        make recordtester
 
     - name: Compress Posix
       if: matrix.os != 'windows-latest'
@@ -88,7 +88,7 @@ jobs:
         gzip -9 -S .${{runner.os}}.gz mapi
         gzip -9 -S .${{runner.os}}.gz recordtester
         gzip -9 -S .${{runner.os}}.gz mist-api-connector
-        
+
     - name: Compress Windows
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -23,16 +23,15 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        tags-prefix: load-tester
         force-latest: true
 
     - name: Build the Docker image
       run: |
-        TAGS=(${{ steps.tags.outputs.tags }})
-        docker build . --file Dockerfile.load-tester ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
+        TAGS='${{ steps.tags.outputs.tags }}'
+        docker build . --file Dockerfile.load-tester $(printf ' -t livepeer/loadtester:%s' $TAGS) --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |
         for TAG in ${{ steps.tags.outputs.tags }}; do
-          docker push livepeer/streamtester:$TAG
+          docker push livepeer/loadtester:$TAG
         done

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -17,17 +17,25 @@ jobs:
       env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD 
+      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - name: Get git tag
+      id: git_tag
+      run: |
+        echo ::set-output name=VERSION::$(git describe --tag --dirty)
+    - name: Get build tag
+      id: build_tag
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
     - name: Build the Docker image
-      # run: docker build . --file Dockerfile --tag livepeer/streamtester:$(date +%s)
-      run: docker build . --file Dockerfile.load-tester --tag livepeer/streamtester:load-tester --build-arg version=$(git describe --dirty)
-    - name: Get tag name
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: docker build . --file Dockerfile.load-tester --tag livepeer/streamtester:load-tester --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+
     - name: Tag version
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        docker tag livepeer/streamtester:load-tester livepeer/streamtester:load-tester${{ steps.get_version.outputs.VERSION }}
-        docker push livepeer/streamtester:load-tester${{ steps.get_version.outputs.VERSION }}
+        docker tag livepeer/streamtester:load-tester livepeer/streamtester:load-tester-${{ steps.build_tag.outputs.VERSION }}
+    - name: Tag git version
+      run: |
+        docker tag livepeer/streamtester:load-tester livepeer/streamtester:load-tester-${{ steps.git_tag.outputs.VERSION }}
     - name: Push Docker Container to Registry
-      run: docker push livepeer/streamtester:load-tester
+      run: |
+        docker push --all-tags livepeer/streamtester

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -24,14 +24,15 @@ jobs:
       uses: livepeer/action-gh-release-tags@v0
       with:
         tags-prefix: load-tester
+        force-latest: true
 
     - name: Build the Docker image
       run: |
-        TAGS=(load-tester ${{ steps.tags.outputs.tags }})
+        TAGS=(${{ steps.tags.outputs.tags }})
         docker build . --file Dockerfile.load-tester ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |
-        for TAG in load-tester ${{ steps.tags.outputs.tags }}; do
+        for TAG in ${{ steps.tags.outputs.tags }}; do
           docker push livepeer/streamtester:$TAG
         done

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -18,24 +18,20 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - name: Get git tag
-      id: git_tag
-      run: |
-        echo ::set-output name=VERSION::$(git describe --tag --dirty)
-    - name: Get build tag
-      id: build_tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+    - name: Tags
+      id: tags
+      uses: livepeer/action-gh-release-tags@v0
+      with:
+        tags-prefix: load-tester
 
     - name: Build the Docker image
-      run: docker build . --file Dockerfile.load-tester --tag livepeer/streamtester:load-tester --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+      run: |
+        TAGS=(load-tester ${{ steps.tags.outputs.tags }})
+        docker build . --file Dockerfile.load-tester ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
-    - name: Tag version
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: |
-        docker tag livepeer/streamtester:load-tester livepeer/streamtester:load-tester-${{ steps.build_tag.outputs.VERSION }}
-    - name: Tag git version
-      run: |
-        docker tag livepeer/streamtester:load-tester livepeer/streamtester:load-tester-${{ steps.git_tag.outputs.VERSION }}
     - name: Push Docker Container to Registry
       run: |
-        docker push --all-tags livepeer/streamtester
+        for TAG in load-tester ${{ steps.tags.outputs.tags }}; do
+          docker push livepeer/streamtester:$TAG
+        done

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - mist-api-connector
+      - feat/tagged-builds
 
 jobs:
 
@@ -26,19 +27,22 @@ jobs:
       id: build_tag
       run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile.mist-api-connector --tag livepeer/streamtester:mist-api-connector --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+    - name: Tags
+      id: tags
+      uses: livepeer/action-gh-release-tags@v0
+      with:
+        tags-prefix: mist-api-connector
 
-    - name: Tag version
-      if: startsWith(github.ref, 'refs/tags/v')
+    - name: Build the Docker image
       run: |
-        docker tag livepeer/streamtester:mist-api-connector livepeer/streamtester:mist-api-connector-${{ steps.build_tag.outputs.VERSION }}
-    - name: Tag git version
-      run: |
-        docker tag livepeer/streamtester:mist-api-connector livepeer/streamtester:mist-api-connector-${{ steps.git_tag.outputs.VERSION }}
+        TAGS=(${{ steps.tags.outputs.tags }})
+        docker build . --file Dockerfile.mist-api-connector ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg version=${{ steps.tags.outputs.version }}
+
     - name: Push Docker Container to Registry
       run: |
-        docker push --all-tags livepeer/streamtester
+        for TAG in ${{ steps.tags.outputs.tags }}; do
+          docker push livepeer/streamtester:$TAG
+        done
 
     - name: Notify that new build has been uploaded
       run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -23,18 +23,17 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        tags-prefix: mist-api-connector
         force-latest: true
 
     - name: Build the Docker image
       run: |
-        TAGS=(${{ steps.tags.outputs.tags }})
-        docker build . --file Dockerfile.mist-api-connector ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
+        TAGS='${{ steps.tags.outputs.tags }}'
+        docker build . --file Dockerfile.mist-api-connector $(printf ' -t livepeer/mist-api-connector:%s' $TAGS) --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |
         for TAG in ${{ steps.tags.outputs.tags }}; do
-          docker push livepeer/streamtester:$TAG
+          docker push livepeer/mist-api-connector:$TAG
         done
 
     - name: Notify that new build has been uploaded

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - mist-api-connector
+      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -19,13 +19,6 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - name: Get git tag
-      id: git_tag
-      run: |
-        echo ::set-output name=VERSION::$(git describe --tag --dirty)
-    - name: Get build tag
-      id: build_tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
     - name: Tags
       id: tags
@@ -36,7 +29,7 @@ jobs:
     - name: Build the Docker image
       run: |
         TAGS=(${{ steps.tags.outputs.tags }})
-        docker build . --file Dockerfile.mist-api-connector ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg version=${{ steps.tags.outputs.version }}
+        docker build . --file Dockerfile.mist-api-connector ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - mist-api-connector
-      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -17,20 +17,28 @@ jobs:
       env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD 
+      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - name: Get git tag
+      id: git_tag
+      run: |
+        echo ::set-output name=VERSION::$(git describe --tag --dirty)
+    - name: Get build tag
+      id: build_tag
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
     - name: Build the Docker image
-      # run: docker build . --file Dockerfile --tag livepeer/streamtester:$(date +%s)
-      run: docker build . --file Dockerfile.mist-api-connector --tag livepeer/streamtester:mist-api-connector --build-arg version=$(git describe --dirty)
-    - name: Get tag name
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: docker build . --file Dockerfile.mist-api-connector --tag livepeer/streamtester:mist-api-connector --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+
     - name: Tag version
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        docker tag livepeer/streamtester:mist-api-connector livepeer/streamtester:mist-api-connector${{ steps.get_version.outputs.VERSION }}
-        docker push livepeer/streamtester:mistapiconnector${{ steps.get_version.outputs.VERSION }}
+        docker tag livepeer/streamtester:mist-api-connector livepeer/streamtester:mist-api-connector-${{ steps.build_tag.outputs.VERSION }}
+    - name: Tag git version
+      run: |
+        docker tag livepeer/streamtester:mist-api-connector livepeer/streamtester:mist-api-connector-${{ steps.git_tag.outputs.VERSION }}
     - name: Push Docker Container to Registry
-      run: docker push livepeer/streamtester:mist-api-connector
+      run: |
+        docker push --all-tags livepeer/streamtester
 
     - name: Notify that new build has been uploaded
       run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -24,6 +24,7 @@ jobs:
       uses: livepeer/action-gh-release-tags@v0
       with:
         tags-prefix: mist-api-connector
+        force-latest: true
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -17,25 +17,26 @@ jobs:
       env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD 
+      run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    - name: Get git tag
+      id: git_tag
+      run: |
+        echo ::set-output name=VERSION::$(git describe --tag --dirty)
+    - name: Get build tag
+      id: build_tag
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
     - name: Build the Docker image
       # run: docker build . --file Dockerfile --tag livepeer/streamtester:$(date +%s)
-      run: docker build . --file Dockerfile.record-tester --tag livepeer/streamtester:record-tester --build-arg version=$(git describe --dirty)
-    - name: Get tag name
-      id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: docker build . --file Dockerfile.record-tester --tag livepeer/streamtester:record-tester --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+
     - name: Tag version
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        docker tag livepeer/streamtester:record-tester livepeer/streamtester:record-tester${{ steps.get_version.outputs.VERSION }}
-        docker push livepeer/streamtester:record-tester${{ steps.get_version.outputs.VERSION }}
-    - name: Describe
-      id: describe
+        docker tag livepeer/streamtester:record-tester livepeer/streamtester:record-tester-${{ steps.build_tag.outputs.VERSION }}
+    - name: Tag git version
       run: |
-        VER=$(git describe)
-        echo "version_from_git=$VER" >> $GITHUB_ENV
+        docker tag livepeer/streamtester:record-tester livepeer/streamtester:record-tester-${{ steps.git_tag.outputs.VERSION }}
     - name: Push Docker Container to Registry
       run: |
-        docker tag livepeer/streamtester:record-tester livepeer/streamtester:record-tester-${{ env.version_from_git }}
-        docker push livepeer/streamtester:record-tester
-        docker push livepeer/streamtester:record-tester-${{ env.version_from_git }}
+        docker push --all-tags livepeer/streamtester

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat/tagged-builds
 
 jobs:
 

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -23,16 +23,15 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        tags-prefix: record-tester
         force-latest: true
 
     - name: Build the Docker image
       run: |
-        TAGS=(${{ steps.tags.outputs.tags }})
-        docker build . --file Dockerfile.record-tester ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
+        TAGS='${{ steps.tags.outputs.tags }}'
+        docker build . --file Dockerfile.record-tester $(printf ' -t livepeer/record-tester:%s' $TAGS) --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |
         for TAG in ${{ steps.tags.outputs.tags }}; do
-          docker push livepeer/streamtester:$TAG
+          docker push livepeer/record-tester:$TAG
         done

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -24,14 +24,15 @@ jobs:
       uses: livepeer/action-gh-release-tags@v0
       with:
         tags-prefix: record-tester
+        force-latest: true
 
     - name: Build the Docker image
       run: |
-        TAGS=(record-tester ${{ steps.tags.outputs.tags }})
+        TAGS=(${{ steps.tags.outputs.tags }})
         docker build . --file Dockerfile.record-tester ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
     - name: Push Docker Container to Registry
       run: |
-        for TAG in record-tester ${{ steps.tags.outputs.tags }}; do
+        for TAG in ${{ steps.tags.outputs.tags }}; do
           docker push livepeer/streamtester:$TAG
         done

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -18,25 +18,20 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    - name: Get git tag
-      id: git_tag
-      run: |
-        echo ::set-output name=VERSION::$(git describe --tag --dirty)
-    - name: Get build tag
-      id: build_tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+    - name: Tags
+      id: tags
+      uses: livepeer/action-gh-release-tags@v0
+      with:
+        tags-prefix: record-tester
 
     - name: Build the Docker image
-      # run: docker build . --file Dockerfile --tag livepeer/streamtester:$(date +%s)
-      run: docker build . --file Dockerfile.record-tester --tag livepeer/streamtester:record-tester --build-arg version=${{ steps.git_tag.outputs.VERSION }}
+      run: |
+        TAGS=(record-tester ${{ steps.tags.outputs.tags }})
+        docker build . --file Dockerfile.record-tester ${TAGS[@]/#/--tag livepeer/streamtester:} --build-arg "version=${{ steps.tags.outputs.version }}"
 
-    - name: Tag version
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: |
-        docker tag livepeer/streamtester:record-tester livepeer/streamtester:record-tester-${{ steps.build_tag.outputs.VERSION }}
-    - name: Tag git version
-      run: |
-        docker tag livepeer/streamtester:record-tester livepeer/streamtester:record-tester-${{ steps.git_tag.outputs.VERSION }}
     - name: Push Docker Container to Registry
       run: |
-        docker push --all-tags livepeer/streamtester
+        for TAG in record-tester ${{ steps.tags.outputs.tags }}; do
+          docker push livepeer/streamtester:$TAG
+        done


### PR DESCRIPTION
Following up on https://github.com/livepeer/livepeer-infra/pull/686, we would like to have some version tags
in all of our repos. This is the first repo after `livepeer-data` being updated to this new format.

Differently from `livepeer-data`, I haven't really repeated [the whole logic](https://github.com/livepeer/livepeer-data/compare/v0.2.1...v0.2.4#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R3) of grabbing the containing
branch for a tag build, nor have I enabled `tag` event builds for our docker images (only the release workflow
is actually run on those).

I will try to create a github action that extracts all the raw tags that we want to publish for a given image to
avoid repating that script everywhere else.