### PR TITLE
mist-api-connector: Add retries to `/setactive` request

### DIFF
--- a/apis/livepeer/livepeer.go
+++ b/apis/livepeer/livepeer.go
@@ -600,6 +600,22 @@ func (lapi *API) GetSessions(id string, forceUrl bool) ([]UserSession, error) {
 	return r, nil
 }
 
+// SetActiveR sets stream active with retries
+func (lapi *API) SetActiveR(id string, active bool, startedAt time.Time) (bool, error) {
+	var apiTry int
+	for {
+		ok, err := lapi.SetActive(id, active, startedAt)
+		if err != nil {
+			if Timedout(err) && apiTry < 3 {
+				apiTry++
+				continue
+			}
+			glog.Errorf("Fatal error calling API /setactive id=%s active=%s err=%v", id, active, err)
+		}
+		return ok, err
+	}
+}
+
 // SetActive set isActive
 func (lapi *API) SetActive(id string, active bool, startedAt time.Time) (bool, error) {
 	if id == "" {

--- a/apis/livepeer/livepeer.go
+++ b/apis/livepeer/livepeer.go
@@ -654,7 +654,7 @@ func (lapi *API) SetActive(id string, active bool, startedAt time.Time) (bool, e
 	took := time.Since(start)
 	metrics.APIRequest("set_active", took, nil)
 	glog.Infof("%s/setactive took=%s response status code %d status %s resp %+v body=%s",
-		took, id, resp.StatusCode, resp.Status, resp, string(b))
+		id, took, resp.StatusCode, resp.Status, resp, string(b))
 	return resp.StatusCode >= 200 && resp.StatusCode < 300, nil
 }
 

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -314,7 +314,7 @@ func (mc *mac) triggerConnClose(w http.ResponseWriter, r *http.Request, lines []
 		mc.mu.Lock()
 		if info, has := mc.pub2info[playbackID]; has {
 			glog.Infof("Setting stream's protocol=%s manifestID=%s playbackID=%s active status to false", protocol, info.id, playbackID)
-			_, err := mc.lapi.SetActive(info.id, false, info.startedAt)
+			_, err := mc.lapi.SetActiveR(info.id, false, info.startedAt)
 			if err != nil {
 				glog.Error(err)
 			}
@@ -566,7 +566,7 @@ func (mc *mac) triggerPushRewrite(w http.ResponseWriter, r *http.Request, lines 
 		} else {
 			responseName = mc.wildcardPlaybackID(stream)
 		}
-		ok, err := mc.lapi.SetActive(stream.ID, true, mc.pub2info[stream.PlaybackID].startedAt)
+		ok, err := mc.lapi.SetActiveR(stream.ID, true, mc.pub2info[stream.PlaybackID].startedAt)
 		if err != nil {
 			glog.Error(err)
 		} else if !ok {


### PR DESCRIPTION
This is to add a couple retries to the `/setactive` call to the API, to hopefully diminish the inconsistencies
we observe on some streams that are actually active but the state on the database say they are not.

Also added a log that we should create an alert on.