### PR TITLE
.github/ci: Build images on every branch

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,14 +1,8 @@
 name: Docker Image CI
-
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +17,7 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        force-latest: true
+        always-latest-on-branch: master
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/load-tester-dockerimage.yml
+++ b/.github/workflows/load-tester-dockerimage.yml
@@ -1,14 +1,8 @@
 name: Load Tester Docker Image CI
-
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +17,7 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        force-latest: true
+        always-latest-on-branch: master
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -16,8 +16,6 @@ jobs:
     - name: Tags
       id: tags
       uses: livepeer/action-gh-release-tags@v0
-      with:
-        always-latest-on-branch: mist-api-connector
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/mist-api-connector-dockerimage.yml
+++ b/.github/workflows/mist-api-connector-dockerimage.yml
@@ -1,14 +1,8 @@
 name: Mist API Connector Docker Image CI
-
-on:
-  push:
-    branches:
-      - mist-api-connector
+on: push
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +17,7 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        force-latest: true
+        always-latest-on-branch: mist-api-connector
 
     - name: Build the Docker image
       run: |

--- a/.github/workflows/record-tester-dockerimage.yml
+++ b/.github/workflows/record-tester-dockerimage.yml
@@ -1,14 +1,8 @@
 name: Record Tester Docker Image CI
-
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +17,7 @@ jobs:
       id: tags
       uses: livepeer/action-gh-release-tags@v0
       with:
-        force-latest: true
+        always-latest-on-branch: master
 
     - name: Build the Docker image
       run: |


### PR DESCRIPTION
Use the `always-latest-on-branch` input to the gh action (created [here](https://github.com/livepeer/action-gh-release-tags/commit/1442c82d03ecfc7adf61e5c4c8c796bda167812b))
so we only publish `latest` tags on the specified branches.

While `latest` will only be pushed on those branches, we can still test the
generated images from any branch since I removed the action filter to only
run on master/mist-api-connector branch.

Also thinking if I should get rid of the `mist-api-connector` branch. Will
create a discussion inline.