### PR TITLE
mist-api-connector: Export metrics for multistream usage minutes/bytes

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -72,10 +72,12 @@ type (
 	}
 
 	pushStatus struct {
-		pushStartEmitted bool
-		pushStopped      bool
 		target           *livepeer.MultistreamTarget
 		profile          string
+		pushStartEmitted bool
+		pushStopped      bool
+		pushedMinutes    float64
+		pushedBytes      int64
 	}
 
 	streamInfo struct {

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -76,8 +76,8 @@ type (
 		profile          string
 		pushStartEmitted bool
 		pushStopped      bool
-		pushedMinutes    float64
 		pushedBytes      int64
+		pushedMediaTime  time.Duration
 	}
 
 	streamInfo struct {

--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -25,6 +25,9 @@ type metricsCollector struct {
 }
 
 func startMetricsCollector(ctx context.Context, period time.Duration, nodeID, ownRegion string, mapi *mist.API, producer *event.AMQPProducer, amqpExchange string, infop infoProvider) {
+	census.IncMultistreamBytes(0)
+	census.IncMultistreamTime(0)
+
 	mc := &metricsCollector{nodeID, ownRegion, mapi, producer, amqpExchange, infop}
 	go mc.mainLoop(ctx, period)
 }

--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -94,10 +94,14 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 				Bytes:       push.Stats.Bytes,
 				MediaTimeMs: push.Stats.MediaTime,
 			}
-			mediaTime := time.Duration(metrics.MediaTimeMs) * time.Millisecond
-			census.IncMultistreamMetrics(metrics.Bytes-pushInfo.pushedBytes, mediaTime-pushInfo.pushedMediaTime)
-			pushInfo.pushedBytes = metrics.Bytes
-			pushInfo.pushedMediaTime = mediaTime
+			if metrics.Bytes > pushInfo.pushedBytes {
+				census.IncMultistreamBytes(metrics.Bytes - pushInfo.pushedBytes)
+				pushInfo.pushedBytes = metrics.Bytes
+			}
+			if mediaTime := time.Duration(metrics.MediaTimeMs) * time.Millisecond; mediaTime > pushInfo.pushedMediaTime {
+				census.IncMultistreamTime(mediaTime - pushInfo.pushedMediaTime)
+				pushInfo.pushedMediaTime = mediaTime
+			}
 		}
 		multistream[i] = &data.MultistreamTargetMetrics{
 			Target:  pushToMultistreamTargetInfo(pushInfo),

--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -11,8 +11,6 @@ import (
 	"github.com/livepeer/stream-tester/apis/mist"
 )
 
-const msPerMinute = 60 * 1000
-
 type infoProvider interface {
 	getStreamInfo(mistID string) *streamInfo
 }
@@ -96,7 +94,7 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 				MediaTimeMs: push.Stats.MediaTime,
 			}
 			pushInfo.pushedBytes = metrics.Bytes
-			pushInfo.pushedMinutes = float64(metrics.MediaTimeMs) / msPerMinute
+			pushInfo.pushedMediaTime = time.Duration(metrics.MediaTimeMs) * time.Millisecond
 		}
 		multistream[i] = &data.MultistreamTargetMetrics{
 			Target:  pushToMultistreamTargetInfo(pushInfo),

--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/livepeer/livepeer-data/pkg/event"
 	"github.com/livepeer/stream-tester/apis/mist"
+	census "github.com/livepeer/stream-tester/internal/metrics"
 )
 
 type infoProvider interface {
@@ -93,8 +94,10 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 				Bytes:       push.Stats.Bytes,
 				MediaTimeMs: push.Stats.MediaTime,
 			}
+			mediaTime := time.Duration(metrics.MediaTimeMs) * time.Millisecond
+			census.IncMultistreamMetrics(metrics.Bytes-pushInfo.pushedBytes, mediaTime-pushInfo.pushedMediaTime)
 			pushInfo.pushedBytes = metrics.Bytes
-			pushInfo.pushedMediaTime = time.Duration(metrics.MediaTimeMs) * time.Millisecond
+			pushInfo.pushedMediaTime = mediaTime
 		}
 		multistream[i] = &data.MultistreamTargetMetrics{
 			Target:  pushToMultistreamTargetInfo(pushInfo),

--- a/internal/metrics/census.go
+++ b/internal/metrics/census.go
@@ -35,8 +35,8 @@ type (
 		mSegmentsToDownload   *stats.Int64Measure
 		mSegmentsToDownloaded *stats.Int64Measure
 
-		mMultistreamUsageMin *stats.Float64Measure
 		mMultistreamUsageMb  *stats.Float64Measure
+		mMultistreamUsageMin *stats.Float64Measure
 
 		mStartupLatency   *stats.Float64Measure
 		mTranscodeLatency *stats.Float64Measure
@@ -95,8 +95,8 @@ func InitCensus(nodeID, version, namespace string) {
 	Census.mSegmentsToDownload = stats.Int64("segments_to_download", "Number of segments queued for download", "tot")
 	Census.mSegmentsToDownloaded = stats.Int64("segments_downloaded", "Number of segments downloaded", "tot")
 
-	Census.mMultistreamUsageMin = stats.Float64("multistream_usage_minutes", "Total minutes multistreamed, or pushed, to external services", "min")
 	Census.mMultistreamUsageMb = stats.Float64("multistream_usage_megabytes", "Total number of megabytes multistreamed, or pushed, to external services", "megabyte")
+	Census.mMultistreamUsageMin = stats.Float64("multistream_usage_minutes", "Total minutes multistreamed, or pushed, to external services", "min")
 
 	glog.Infof("Compiler: %s Arch %s OS %s Go version %s", runtime.Compiler, runtime.GOARCH, runtime.GOOS, runtime.Version())
 	glog.Infof("Streamtester version: %s", version)
@@ -151,16 +151,16 @@ func InitCensus(nodeID, version, namespace string) {
 			Aggregation: view.Count(),
 		},
 		{
-			Name:        "multistream_usage_minutes",
-			Measure:     Census.mMultistreamUsageMin,
-			Description: "Total minutes multistreamed, or pushed, to external services",
+			Name:        "multistream_usage_megabytes",
+			Measure:     Census.mMultistreamUsageMb,
+			Description: "Total number of bytes multistreamed, or pushed, to external services",
 			TagKeys:     baseTags,
 			Aggregation: view.Sum(),
 		},
 		{
-			Name:        "multistream_usage_megabytes",
-			Measure:     Census.mMultistreamUsageMb,
-			Description: "Total number of bytes multistreamed, or pushed, to external services",
+			Name:        "multistream_usage_minutes",
+			Measure:     Census.mMultistreamUsageMin,
+			Description: "Total minutes multistreamed, or pushed, to external services",
 			TagKeys:     baseTags,
 			Aggregation: view.Sum(),
 		},

--- a/internal/metrics/census.go
+++ b/internal/metrics/census.go
@@ -153,7 +153,7 @@ func InitCensus(nodeID, version, namespace string) {
 		{
 			Name:        "multistream_usage_megabytes",
 			Measure:     Census.mMultistreamUsageMb,
-			Description: "Total number of bytes multistreamed, or pushed, to external services",
+			Description: "Total number of megabytes multistreamed, or pushed, to external services",
 			TagKeys:     baseTags,
 			Aggregation: view.Sum(),
 		},


### PR DESCRIPTION
They will be globally aggregated on Victoria Metrics and retained for at least 30 days, so
that we can create with a view for the total number of multistreamed minutes (and bytes)
per month.

This implements https://github.com/livepeer/livepeer-com/issues/675
