### PR TITLE
make: Create `make release` command to tag and update `mapic-release` branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,5 +57,9 @@ release:
 		exit 1 ; \
 	fi
 	@git diff --quiet || { echo "Git working directory is dirty." && exit 1 ; }
-	# git tag -a v$(version) -m "Release v$(version)"
-	echo gogo $(version)
+
+	git tag -a v$(version) -m "Release v$(version)"
+	git push origin v$(version)
+
+	git merge --ff-only mapic-release
+	git push origin mapic-release

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,14 @@ localdocker:
 .PHONY: stream-monitor
 monitor:
 	go build -ldflags="$(ldflags)" cmd/stream-monitor/stream-monitor.go
+
+.PHONY: release
+release:
+	@if [[ ! "$(version)" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]]; then \
+		echo "Must provide semantic version as arg to make." ; \
+		echo "e.g. make release version=1.2.3-beta" ; \
+		exit 1 ; \
+	fi
+	@git diff --quiet || { echo "Git working directory is dirty." && exit 1 ; }
+	# git tag -a v$(version) -m "Release v$(version)"
+	echo gogo $(version)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,6 @@ release:
 	@echo -n "Release mist-api-connector? [y] "
 	@read ans && [ $${ans:-y} = y ] || { echo "Mapic release aborted, branch not fast-forwarded."; exit 1 ; }
 
-	git checkout mapic-release-test
+	git checkout mapic-release
 	git merge --ff-only v$(version)
-	git push origin mapic-release-test
+	git push origin mapic-release

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,14 @@ release:
 		echo "e.g. make release version=1.2.3-beta" ; \
 		exit 1 ; \
 	fi
-	@git diff --quiet || { echo "Git working directory is dirty." && exit 1 ; }
+	@git diff --quiet || { echo "Git working directory is dirty."; exit 1 ; }
 
 	git tag -a v$(version) -m "Release v$(version)"
 	git push origin v$(version)
 
-	git merge --ff-only v$(version) mapic-release-test
+	@echo -n "Release mist-api-connector? [y] "
+	@read ans && [ $${ans:-y} = y ] || { echo "Mapic release aborted, branch not fast-forwarded."; exit 1 ; }
+
+	git checkout mapic-release-test
+	git merge --ff-only v$(version)
 	git push origin mapic-release-test

--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ release:
 	git tag -a v$(version) -m "Release v$(version)"
 	git push origin v$(version)
 
-	git merge --ff-only mapic-release
-	git push origin mapic-release
+	git merge --ff-only v$(version) mapic-release-test
+	git push origin mapic-release-test


### PR DESCRIPTION
Idea came from https://github.com/livepeer/livepeer-infra/pull/738#issuecomment-988345269 to make the release process a little easier.