### PR TITLE
Follow consistent naming for all release artifacts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,50 +84,9 @@ jobs:
 
       - name: Release Posix
         uses: softprops/action-gh-release@v1
-        # if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            build/livepeer-lapi-darwin-amd64.tar.gz
-            build/livepeer-lapi-darwin-arm64.tar.gz
-            build/livepeer-lapi-linux-amd64.tar.gz
-            build/livepeer-lapi-linux-arm64.tar.gz
-            build/livepeer-lapi-windows-amd64.zip
-            build/livepeer-lapi-windows-arm64.zip
-            build/livepeer-loadtester-darwin-amd64.tar.gz
-            build/livepeer-loadtester-darwin-arm64.tar.gz
-            build/livepeer-loadtester-linux-amd64.tar.gz
-            build/livepeer-loadtester-linux-arm64.tar.gz
-            build/livepeer-loadtester-windows-amd64.zip
-            build/livepeer-loadtester-windows-arm64.zip
-            build/livepeer-mapi-darwin-amd64.tar.gz
-            build/livepeer-mapi-darwin-arm64.tar.gz
-            build/livepeer-mapi-linux-amd64.tar.gz
-            build/livepeer-mapi-linux-arm64.tar.gz
-            build/livepeer-mapi-windows-amd64.zip
-            build/livepeer-mapi-windows-arm64.zip
-            build/livepeer-mist-api-connector-darwin-amd64.tar.gz
-            build/livepeer-mist-api-connector-darwin-arm64.tar.gz
-            build/livepeer-mist-api-connector-linux-amd64.tar.gz
-            build/livepeer-mist-api-connector-linux-arm64.tar.gz
-            build/livepeer-mist-api-connector-windows-amd64.zip
-            build/livepeer-mist-api-connector-windows-arm64.zip
-            build/livepeer-recordtester-darwin-amd64.tar.gz
-            build/livepeer-recordtester-darwin-arm64.tar.gz
-            build/livepeer-recordtester-linux-amd64.tar.gz
-            build/livepeer-recordtester-linux-arm64.tar.gz
-            build/livepeer-recordtester-windows-amd64.zip
-            build/livepeer-recordtester-windows-arm64.zip
-            build/livepeer-streamtester-darwin-amd64.tar.gz
-            build/livepeer-streamtester-darwin-arm64.tar.gz
-            build/livepeer-streamtester-linux-amd64.tar.gz
-            build/livepeer-streamtester-linux-arm64.tar.gz
-            build/livepeer-streamtester-windows-amd64.zip
-            build/livepeer-streamtester-windows-arm64.zip
-            build/livepeer-testdriver-darwin-amd64.tar.gz
-            build/livepeer-testdriver-darwin-arm64.tar.gz
-            build/livepeer-testdriver-linux-amd64.tar.gz
-            build/livepeer-testdriver-linux-arm64.tar.gz
-            build/livepeer-testdriver-windows-amd64.zip
-            build/livepeer-testdriver-windows-arm64.zip
+            build/livepeer-*.tar.gz
+            build/livepeer-*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           for arch in arm64 amd64
           do
-            GOARCH="$arch" make all GO_BUILD_DIR="build/${arch}/"
+            GOARCH="$arch" make all GO_BUILD_DIR="build/${RUNNER_OS}/${arch}/"
           done
 
       - name: Compress Posix
@@ -81,7 +81,7 @@ jobs:
         run: |
           for arch in arm64 amd64
           do
-            cd "build/${arch}"
+            cd "build/${RUNNER_OS}/${arch}"
             for file in "$(find . -type f -perm -a+x)"
             do
               mv "${file}" "livepeer-${file}"
@@ -96,7 +96,7 @@ jobs:
         run: |
           for arch in arm64 amd64
           do
-            cd "build/${arch}"
+            cd "build/${RUNNER_OS}/${arch}"
             for file in "$(find . -type f -perm -a+x)"
             do
               mv "${file}" "livepeer-${file}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,46 +4,44 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "hjp/*"
 
 jobs:
-  # test:
-  #   name: Test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Go 1.15
-  #       uses: actions/setup-go@v1
-  #       with:
-  #         go-version: 1.15
-  #       id: go
-  #     - name: Check out code into the Go module directory
-  #       uses: actions/checkout@v1
-  #     - name: Get dependencies
-  #       run: |
-  #         go get -v -t -d ./...
-  #     - name: Check that can be compiled
-  #       run: go build -v cmd/streamtester/streamtester.go
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+      - name: Check that can be compiled
+        run: go build -v cmd/streamtester/streamtester.go
 
-  # create_release:
-  #   name: Create Release
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@master
-  #     - name: Create Release
-  #       id: create_release
-  #       uses: actions/create-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         tag_name: ${{ github.ref }}
-  #         release_name: Release ${{ github.ref }}
-  #         body: |
-  #           Release ${{ github.ref }}
-  #         draft: false
-  #         prerelease: false
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Release ${{ github.ref }}
+          draft: false
+          prerelease: false
 
   build:
     name: Build
@@ -66,7 +64,7 @@ jobs:
           do
             for arch in arm64 amd64
             do
-              GOOS="$platform" GOARCH="$arch" make -j$(nproc) all GO_BUILD_DIR="build/${platform}/${arch}/"
+              GOOS="$platform" GOARCH="$arch" make -j4 all GO_BUILD_DIR="build/${platform}/${arch}/"
               cd "build/${platform}/${arch}"
               for file in $(find . -type f -perm -a+x)
               do
@@ -82,31 +80,54 @@ jobs:
               cd -
             done
           done
-          ls -lhR build/
+          find . -type f -name 'livepeer-*.zip' -o 'livepeer-*.tar.gz' -exec mv -t build/ {} \+
 
-      # - name: Release Posix
-      #   uses: softprops/action-gh-release@v1
-      #   # if: startsWith(github.ref, 'refs/tags/')
-      #   if: matrix.os != 'windows-latest'
-      #   with:
-      #     files: |
-      #       streamtester.${{runner.os}}.gz
-      #       loadtester.${{runner.os}}.gz
-      #       recordtester.${{runner.os}}.gz
-      #       lapi.${{runner.os}}.gz
-      #       mapi.${{runner.os}}.gz
-      #       testdriver.${{runner.os}}.gz
-      #       mist-api-connector.${{runner.os}}.gz
-      #     # body_path: ${{ github.workflow }}-CHANGELOG.txt
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Release Windows
-      #   uses: softprops/action-gh-release@v1
-      #   if: matrix.os == 'windows-latest'
-      #   with:
-      #     files:
-      #       streamtester.${{runner.os}}.zip
-      #       # body_path: ${{ github.workflow }}-CHANGELOG.txt
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release Posix
+        uses: softprops/action-gh-release@v1
+        # if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            build/livepeer-lapi-darwin-amd64.tar.gz
+            build/livepeer-lapi-darwin-arm64.tar.gz
+            build/livepeer-lapi-linux-amd64.tar.gz
+            build/livepeer-lapi-linux-arm64.tar.gz
+            build/livepeer-lapi-windows-amd64.zip
+            build/livepeer-lapi-windows-arm64.zip
+            build/livepeer-loadtester-darwin-amd64.tar.gz
+            build/livepeer-loadtester-darwin-arm64.tar.gz
+            build/livepeer-loadtester-linux-amd64.tar.gz
+            build/livepeer-loadtester-linux-arm64.tar.gz
+            build/livepeer-loadtester-windows-amd64.zip
+            build/livepeer-loadtester-windows-arm64.zip
+            build/livepeer-mapi-darwin-amd64.tar.gz
+            build/livepeer-mapi-darwin-arm64.tar.gz
+            build/livepeer-mapi-linux-amd64.tar.gz
+            build/livepeer-mapi-linux-arm64.tar.gz
+            build/livepeer-mapi-windows-amd64.zip
+            build/livepeer-mapi-windows-arm64.zip
+            build/livepeer-mist-api-connector-darwin-amd64.tar.gz
+            build/livepeer-mist-api-connector-darwin-arm64.tar.gz
+            build/livepeer-mist-api-connector-linux-amd64.tar.gz
+            build/livepeer-mist-api-connector-linux-arm64.tar.gz
+            build/livepeer-mist-api-connector-windows-amd64.zip
+            build/livepeer-mist-api-connector-windows-arm64.zip
+            build/livepeer-recordtester-darwin-amd64.tar.gz
+            build/livepeer-recordtester-darwin-arm64.tar.gz
+            build/livepeer-recordtester-linux-amd64.tar.gz
+            build/livepeer-recordtester-linux-arm64.tar.gz
+            build/livepeer-recordtester-windows-amd64.zip
+            build/livepeer-recordtester-windows-arm64.zip
+            build/livepeer-streamtester-darwin-amd64.tar.gz
+            build/livepeer-streamtester-darwin-arm64.tar.gz
+            build/livepeer-streamtester-linux-amd64.tar.gz
+            build/livepeer-streamtester-linux-arm64.tar.gz
+            build/livepeer-streamtester-windows-amd64.zip
+            build/livepeer-streamtester-windows-arm64.zip
+            build/livepeer-testdriver-darwin-amd64.tar.gz
+            build/livepeer-testdriver-darwin-arm64.tar.gz
+            build/livepeer-testdriver-linux-amd64.tar.gz
+            build/livepeer-testdriver-linux-arm64.tar.gz
+            build/livepeer-testdriver-windows-amd64.zip
+            build/livepeer-testdriver-windows-arm64.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,7 +74,7 @@ jobs:
                 mv "${f_name}" "livepeer-${f_name}"
                 if [ "$platform" = "windows" ]
                 then
-                  zip -9 "livepeer-${f_name/.exe//}-windows-${arch}.zip" "livepeer-${f_name}"
+                  zip -9 "livepeer-${f_name/.exe/}-windows-${arch}.zip" "livepeer-${f_name}"
                 else
                   tar -czf "livepeer-${f_name}-${platform}-${arch}.tar.gz" "livepeer-${f_name}"
                 fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,7 @@ jobs:
           do
             for arch in arm64 amd64
             do
-              GOOS="$platform" GOARCH="$arch" make all GO_BUILD_DIR="build/${platform}/${arch}/"
+              GOOS="$platform" GOARCH="$arch" make -j$(nproc) all GO_BUILD_DIR="build/${platform}/${arch}/"
               cd "build/${platform}/${arch}"
               for file in $(find . -type f -perm -a+x)
               do

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,48 +1,51 @@
 name: Publish new Release
-#on: [push]
+
 on:
   push:
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*"
+    branches:
+      - "hjp/*"
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.15
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-    - name: Check that can be compiled
-      run: go build -v cmd/streamtester/streamtester.go
-
-  create_release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          go-version: 1.15
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+      - name: Check that can be compiled
+        run: go build -v cmd/streamtester/streamtester.go
+
+  # create_release:
+  #   name: Create Release
+  #   runs-on: ubuntu-latest
+  #   needs: test
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@master
+  #     - name: Create Release
+  #       id: create_release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ github.ref }}
+  #         release_name: Release ${{ github.ref }}
+  #         body: |
+  #           Release ${{ github.ref }}
+  #         draft: false
+  #         prerelease: false
 
   build:
     name: Build
@@ -50,72 +53,82 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [macos-latest, ubuntu-latest]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os:
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
     needs: create_release
     steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+      - name: Build
+        run: |
+          for arch in arm64 amd64
+          do
+            GOARCH="$arch" make all GO_BUILD_DIR="build/${arch}/"
+          done
 
-    - name: Set up Go 1.15
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.15
-      id: go
+      - name: Compress Posix
+        if: matrix.os != 'windows-latest'
+        run: |
+          for arch in arm64 amd64
+          do
+            cd "build/${arch}"
+            for file in "$(find . -type f -perm -a+x)"
+            do
+              mv "${file}" "livepeer-${file}"
+              tar -czf "livepeer-${file}-${RUNNER_OS}-${arch}.tar.gz" "livepeer-${file}"
+            done
+            cd -
+          done
+          ls -lhR build/
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      - name: Compress Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          for arch in arm64 amd64
+          do
+            cd "build/${arch}"
+            for file in "$(find . -type f -perm -a+x)"
+            do
+              mv "${file}" "livepeer-${file}"
+              7z a "livepeer-${file}-${RUNNER_OS}-${arch}.zip" "livepeer-${file}"
+            done
+            cd -
+          done
+          ls -lhR build/
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
+      # - name: Release Posix
+      #   uses: softprops/action-gh-release@v1
+      #   # if: startsWith(github.ref, 'refs/tags/')
+      #   if: matrix.os != 'windows-latest'
+      #   with:
+      #     files: |
+      #       streamtester.${{runner.os}}.gz
+      #       loadtester.${{runner.os}}.gz
+      #       recordtester.${{runner.os}}.gz
+      #       lapi.${{runner.os}}.gz
+      #       mapi.${{runner.os}}.gz
+      #       testdriver.${{runner.os}}.gz
+      #       mist-api-connector.${{runner.os}}.gz
+      #     # body_path: ${{ github.workflow }}-CHANGELOG.txt
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build
-      run: |
-        make
-        make testdriver
-        make lapi
-        make mapi
-        make connector
-        make loadtester
-        make recordtester
-
-    - name: Compress Posix
-      if: matrix.os != 'windows-latest'
-      run: |
-        gzip -9 -S .${{runner.os}}.gz streamtester
-        gzip -9 -S .${{runner.os}}.gz loadtester
-        gzip -9 -S .${{runner.os}}.gz lapi
-        gzip -9 -S .${{runner.os}}.gz testdriver
-        gzip -9 -S .${{runner.os}}.gz mapi
-        gzip -9 -S .${{runner.os}}.gz recordtester
-        gzip -9 -S .${{runner.os}}.gz mist-api-connector
-
-    - name: Compress Windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        7z a streamtester.${{runner.os}}.zip streamtester.exe
-
-    - name: Release Posix
-      uses: softprops/action-gh-release@v1
-      # if: startsWith(github.ref, 'refs/tags/')
-      if: matrix.os != 'windows-latest'
-      with:
-        files: |
-            streamtester.${{runner.os}}.gz
-            loadtester.${{runner.os}}.gz
-            recordtester.${{runner.os}}.gz
-            lapi.${{runner.os}}.gz
-            mapi.${{runner.os}}.gz
-            testdriver.${{runner.os}}.gz
-            mist-api-connector.${{runner.os}}.gz
-          # body_path: ${{ github.workflow }}-CHANGELOG.txt
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Release Windows
-      uses: softprops/action-gh-release@v1
-      if: matrix.os == 'windows-latest'
-      with:
-        files: streamtester.${{runner.os}}.zip
-          # body_path: ${{ github.workflow }}-CHANGELOG.txt
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Release Windows
+      #   uses: softprops/action-gh-release@v1
+      #   if: matrix.os == 'windows-latest'
+      #   with:
+      #     files:
+      #       streamtester.${{runner.os}}.zip
+      #       # body_path: ${{ github.workflow }}-CHANGELOG.txt
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,14 +47,7 @@ jobs:
 
   build:
     name: Build
-    # runs-on: ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - macos-latest
-          - windows-latest
-          - ubuntu-latest
+    runs-on: macos-latest
     # needs: create_release
     steps:
       - name: Set up Go 1.17
@@ -69,40 +62,25 @@ jobs:
           go get -v -t -d ./...
       - name: Build
         run: |
-          for arch in arm64 amd64
+          for platform in linux darwin windows
           do
-            GOARCH="$arch" make all GO_BUILD_DIR="build/${RUNNER_OS}/${arch}/"
-          done
-
-      - name: Compress Posix
-        if: matrix.os != 'windows-latest'
-        run: |
-          for arch in arm64 amd64
-          do
-            cd "build/${RUNNER_OS}/${arch}"
-            for file in $(find . -type f -perm -a+x)
+            for arch in arm64 amd64
             do
-              f_name="$(basename $file)"
-              mv "${f_name}" "livepeer-${f_name}"
-              tar -czf "livepeer-${f_name}-${RUNNER_OS}-${arch}.tar.gz" "livepeer-${f_name}"
+              GOOS="$platform" GOARCH="$arch" make all GO_BUILD_DIR="build/${platform}/${arch}/"
+              cd "build/${platform}/${arch}"
+              for file in $(find . -type f -perm -a+x)
+              do
+                f_name="$(basename $file)"
+                mv "${f_name}" "livepeer-${f_name}"
+                if [ "$platform" = "windows" ]
+                then
+                  zip -9 "livepeer-${f_name/.exe//}-windows-${arch}.zip" "livepeer-${f_name}"
+                else
+                  tar -czf "livepeer-${f_name}-${platform}-${arch}.tar.gz" "livepeer-${f_name}"
+                fi
+              done
+              cd -
             done
-            cd -
-          done
-          ls -lhR build/
-
-      - name: Compress Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          for arch in arm64 amd64
-          do
-            cd "build/${RUNNER_OS}/${arch}"
-            for file in $(find . -type f -perm -a+x)
-            do
-              f_name="$(basename $file)"
-              mv "${f_name}" "livepeer-${f_name}"
-              7z a "livepeer-${f_name/.exe//}-${RUNNER_OS}-${arch}.zip" "livepeer-${f_name}"
-            done
-            cd -
           done
           ls -lhR build/
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
           - macos-latest
           - windows-latest
           - ubuntu-latest
-    needs: create_release
+    # needs: create_release
     steps:
       - name: Set up Go 1.15
         uses: actions/setup-go@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,24 +8,22 @@ on:
       - "hjp/*"
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.15
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-      - name: Check that can be compiled
-        run: go build -v cmd/streamtester/streamtester.go
+  # test:
+  #   name: Test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Go 1.15
+  #       uses: actions/setup-go@v1
+  #       with:
+  #         go-version: 1.15
+  #       id: go
+  #     - name: Check out code into the Go module directory
+  #       uses: actions/checkout@v1
+  #     - name: Get dependencies
+  #       run: |
+  #         go get -v -t -d ./...
+  #     - name: Check that can be compiled
+  #       run: go build -v cmd/streamtester/streamtester.go
 
   # create_release:
   #   name: Create Release
@@ -59,10 +57,10 @@ jobs:
           - ubuntu-latest
     # needs: create_release
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.17
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,10 +80,11 @@ jobs:
           for arch in arm64 amd64
           do
             cd "build/${RUNNER_OS}/${arch}"
-            for file in "$(find . -type f -perm -a+x)"
+            for file in $(find . -type f -perm -a+x)
             do
-              mv "${file}" "livepeer-${file}"
-              tar -czf "livepeer-${file}-${RUNNER_OS}-${arch}.tar.gz" "livepeer-${file}"
+              f_name="$(basename $file)"
+              mv "${f_name}" "livepeer-${f_name}"
+              tar -czf "livepeer-${f_name}-${RUNNER_OS}-${arch}.tar.gz" "livepeer-${f_name}"
             done
             cd -
           done
@@ -95,10 +96,11 @@ jobs:
           for arch in arm64 amd64
           do
             cd "build/${RUNNER_OS}/${arch}"
-            for file in "$(find . -type f -perm -a+x)"
+            for file in $(find . -type f -perm -a+x)
             do
-              mv "${file}" "livepeer-${file}"
-              7z a "livepeer-${file}-${RUNNER_OS}-${arch}.zip" "livepeer-${file}"
+              f_name="$(basename $file)"
+              mv "${f_name}" "livepeer-${f_name}"
+              7z a "livepeer-${f_name/.exe//}-${RUNNER_OS}-${arch}.zip" "livepeer-${f_name}"
             done
             cd -
           done

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,132 @@
 *.mp4
 *.ts
-/streamtester
 .DS_Store
 tmp
 .cache
 .ash_history
 .env
-/lapi
-/loadtester
-/mapi
-/mist-api-connector
-/testdriver
-/recordtester
+build/
+
+# Created by https://www.toptal.com/developers/gitignore/api/emacs,vim,go,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=emacs,vim,go,visualstudiocode
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+
+# End of https://www.toptal.com/developers/gitignore/api/emacs,vim,go,visualstudiocode

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,42 @@
 SHELL=/bin/bash
+GO_BUILD_DIR?=build/
+ldflags := -X 'github.com/livepeer/stream-tester/model.Version=$(shell git describe --dirty)'
 
 all: streamtester loadtester testdriver lapi mapi recordtester connector
 
-ldflags := -X 'github.com/livepeer/stream-tester/model.Version=$(shell git describe --dirty)'
 # ldflags := -X 'github.com/livepeer/stream-tester/model.Version=$(shell git describe --dirty)' -X 'github.com/livepeer/stream-tester/model.IProduction=true'
 
 .PHONY: streamtester
 streamtester:
-	go build -ldflags="$(ldflags)" cmd/streamtester/streamtester.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/streamtester/streamtester.go
 
 .PHONY: loadtester
 loadtester:
-	go build -ldflags="$(ldflags)" cmd/loadtester/loadtester.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/loadtester/loadtester.go
 
 .PHONY: testdriver
 testdriver:
-	go build -ldflags="$(ldflags)" cmd/testdriver/testdriver.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/testdriver/testdriver.go
 
 .PHONY: lapi
 lapi:
-	go build -ldflags="$(ldflags)" cmd/lapi/lapi.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/lapi/lapi.go
 
 .PHONY: mapi
 mapi:
-	go build -ldflags="$(ldflags)" cmd/mapi/mapi.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/mapi/mapi.go
 
 .PHONY: recordtester
 recordtester:
-	go build -ldflags="$(ldflags)" cmd/recordtester/recordtester.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/recordtester/recordtester.go
 
 .PHONY: connector
 connector:
-	go build -ldflags="$(ldflags)" cmd/mist-api-connector/mist-api-connector.go
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/mist-api-connector/mist-api-connector.go
+
+.PHONY: stream-monitor
+monitor:
+	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)" cmd/stream-monitor/stream-monitor.go
 
 .PHONY: docker
 docker:
@@ -44,10 +49,6 @@ push:
 .PHONY: localdocker
 localdocker:
 	docker build -f Dockerfile.debian -t livepeer/streamtester:latest --build-arg version=$(shell git describe --dirty) .
-
-.PHONY: stream-monitor
-monitor:
-	go build -ldflags="$(ldflags)" cmd/stream-monitor/stream-monitor.go
 
 .PHONY: release
 release:


### PR DESCRIPTION
Creates a naming pattern as defined by #127.

PS: The list of files specified with `files:|` seems too detailed. Should be a wildcard method to achieve the same.