### PR TITLE
record-tester: Allow recording streams to custom object store

### DIFF
--- a/cmd/lapi/lapi.go
+++ b/cmd/lapi/lapi.go
@@ -176,17 +176,18 @@ func main() {
 	}
 }
 
-func createStream(token, presets, name string) (string, *livepeer.API, error) {
-	fmt.Printf("Creating new stream with name %s profiles %s\n", name, presets)
-	profiles := strings.Split(presets, ",")
+func createStream(token, presetsStr, name string) (string, *livepeer.API, error) {
+	fmt.Printf("Creating new stream with name %s presets %s\n", name, presetsStr)
+	presets := strings.Split(presetsStr, ",")
 
 	lapi := livepeer.NewLivepeer(token, server, nil) // hardcode AC server for now
 	lapi.Init()
-	sid, err := lapi.CreateStream(name, profiles...)
+	stream, err := lapi.CreateStream(livepeer.CreateStreamReq{Name: name, Presets: presets})
 	if err != nil {
 		fmt.Println("Error creating stream:")
 		return "", nil, err
 	}
+	sid := stream.ID
 	fmt.Printf("Stream created: %+v", sid)
 	return sid, lapi, nil
 }

--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -55,6 +55,7 @@ func main() {
 	useHttp := fs.Bool("http", false, "Do HTTP tests instead of RTMP")
 	testMP4 := fs.Bool("mp4", false, "Download MP4 of recording")
 	testStreamHealth := fs.Bool("stream-health", false, "Check stream health during test")
+	recordObjectStoreId := fs.String("record-object-store-id", "", "ID for the Object Store to use for recording storage. Forwarded to the streams created in the API")
 	discordURL := fs.String("discord-url", "", "URL of Discord's webhook to send messages to Discord channel")
 	discordUserName := fs.String("discord-user-name", "", "User name to use when sending messages to Discord")
 	discordUsersToNotify := fs.String("discord-users", "", "Id's of users to notify in case of failure")
@@ -198,13 +199,14 @@ func main() {
 	messenger.Init(gctx, *discordURL, *discordUserName, *discordUsersToNotify, "", "", "")
 
 	rtOpts := recordtester.RecordTesterOptions{
-		API:              lapi,
-		Analyzers:        lanalyzers,
-		Ingest:           ingest,
-		UseForceURL:      true,
-		UseHTTP:          *useHttp,
-		TestMP4:          *testMP4,
-		TestStreamHealth: *testStreamHealth,
+		API:                 lapi,
+		Analyzers:           lanalyzers,
+		Ingest:              ingest,
+		RecordObjectStoreId: *recordObjectStoreId,
+		UseForceURL:         true,
+		UseHTTP:             *useHttp,
+		TestMP4:             *testMP4,
+		TestStreamHealth:    *testStreamHealth,
 	}
 	if *sim > 1 {
 		var testers []recordtester.IRecordTester

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -285,7 +285,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	sess := sessions[0]
 	if len(sess.Profiles) != len(stream.Profiles) {
 		glog.Infof("session: %+v", sess)
-		err := fmt.Errorf("got %d, but should have %d", len(sess.Profiles), len(stream.Profiles))
+		err := fmt.Errorf("got %d profiles but should have %d", len(sess.Profiles), len(stream.Profiles))
 		return 251, err
 		// exit(251, fileName, *fileArg, err)
 	}

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -153,7 +153,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format("2006-01-02T15:04:05Z07:00"))
 	var stream *livepeer.CreateStreamResp
 	for {
-		stream, err = rt.lapi.CreateStreamEx(streamName, true, nil, standardProfiles...)
+		stream, err = rt.lapi.CreateStream(livepeer.CreateStreamReq{Name: streamName, Profiles: standardProfiles, Record: true})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++
@@ -386,7 +386,12 @@ func (rt *recordTester) doOneHTTPStream(fileName, streamName, broadcasterURL str
 	var err error
 	apiTry := 0
 	for {
-		session, err = rt.lapi.CreateStreamEx2(streamName, true, stream.ID, nil, standardProfiles...)
+		session, err = rt.lapi.CreateStream(livepeer.CreateStreamReq{
+			Name:     streamName,
+			ParentID: stream.ID,
+			Profiles: standardProfiles,
+			Record:   true,
+		})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -34,28 +34,31 @@ type (
 
 	RecordTesterOptions struct {
 		*livepeer.API
-		Analyzers        testers.AnalyzerByRegion
-		Ingest           *livepeer.Ingest
-		VODStats         model.VODStats
-		UseForceURL      bool
-		UseHTTP          bool
-		TestMP4          bool
-		TestStreamHealth bool
+		Analyzers           testers.AnalyzerByRegion
+		Ingest              *livepeer.Ingest
+		RecordObjectStoreId string
+		UseForceURL         bool
+		UseHTTP             bool
+		TestMP4             bool
+		TestStreamHealth    bool
 	}
 
 	recordTester struct {
-		lapi         *livepeer.API
-		lanalyzers   testers.AnalyzerByRegion
-		ingest       *livepeer.Ingest
-		useForceURL  bool
-		ctx          context.Context
-		cancel       context.CancelFunc
-		vodeStats    model.VODStats
-		streamID     string
-		stream       *livepeer.CreateStreamResp
-		useHTTP      bool
-		mp4          bool
-		streamHealth bool
+		ctx                 context.Context
+		cancel              context.CancelFunc
+		lapi                *livepeer.API
+		lanalyzers          testers.AnalyzerByRegion
+		ingest              *livepeer.Ingest
+		recordObjectStoreId string
+		useForceURL         bool
+		useHTTP             bool
+		mp4                 bool
+		streamHealth        bool
+
+		// mutable fields
+		streamID string
+		stream   *livepeer.CreateStreamResp
+		vodStats model.VODStats
 	}
 )
 
@@ -98,15 +101,16 @@ var standardProfiles = []livepeer.Profile{
 func NewRecordTester(gctx context.Context, opts RecordTesterOptions) IRecordTester {
 	ctx, cancel := context.WithCancel(gctx)
 	rt := &recordTester{
-		lapi:         opts.API,
-		lanalyzers:   opts.Analyzers,
-		ingest:       opts.Ingest,
-		useForceURL:  opts.UseForceURL,
-		ctx:          ctx,
-		cancel:       cancel,
-		useHTTP:      opts.UseHTTP,
-		mp4:          opts.TestMP4,
-		streamHealth: opts.TestStreamHealth,
+		lapi:                opts.API,
+		lanalyzers:          opts.Analyzers,
+		ingest:              opts.Ingest,
+		ctx:                 ctx,
+		cancel:              cancel,
+		recordObjectStoreId: opts.RecordObjectStoreId,
+		useForceURL:         opts.UseForceURL,
+		useHTTP:             opts.UseHTTP,
+		mp4:                 opts.TestMP4,
+		streamHealth:        opts.TestStreamHealth,
 	}
 	return rt
 }
@@ -153,7 +157,12 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format("2006-01-02T15:04:05Z07:00"))
 	var stream *livepeer.CreateStreamResp
 	for {
-		stream, err = rt.lapi.CreateStream(livepeer.CreateStreamReq{Name: streamName, Profiles: standardProfiles, Record: true})
+		stream, err = rt.lapi.CreateStream(livepeer.CreateStreamReq{
+			Name:                streamName,
+			Profiles:            standardProfiles,
+			Record:              true,
+			RecordObjectStoreId: rt.recordObjectStoreId,
+		})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++
@@ -387,10 +396,11 @@ func (rt *recordTester) doOneHTTPStream(fileName, streamName, broadcasterURL str
 	apiTry := 0
 	for {
 		session, err = rt.lapi.CreateStream(livepeer.CreateStreamReq{
-			Name:     streamName,
-			ParentID: stream.ID,
-			Profiles: standardProfiles,
-			Record:   true,
+			Name:                streamName,
+			ParentID:            stream.ID,
+			Profiles:            standardProfiles,
+			Record:              true,
+			RecordObjectStoreId: rt.recordObjectStoreId,
 		})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
@@ -483,7 +493,7 @@ func (rt *recordTester) checkDown(stream *livepeer.CreateStreamResp, url string,
 		return 0, err
 	}
 	vs := downloader.VODStats()
-	rt.vodeStats = vs
+	rt.vodStats = vs
 	if len(vs.SegmentsNum) != len(standardProfiles)+1 {
 		glog.Warningf("Number of renditions doesn't match! Has %d should %d", len(vs.SegmentsNum), len(standardProfiles)+1)
 		es = 35
@@ -509,7 +519,7 @@ func (rt *recordTester) Done() <-chan struct{} {
 }
 
 func (rt *recordTester) VODStats() model.VODStats {
-	return rt.vodeStats
+	return rt.vodStats
 }
 
 func (rt *recordTester) Clean() {

--- a/internal/testers/http_load_tester.go
+++ b/internal/testers/http_load_tester.go
@@ -143,12 +143,12 @@ func (hlt *HTTPLoadTester) startStreams(baseManifestID, sourceFileName string, r
 		}
 		manifestID := fmt.Sprintf("%s_%d_%d", baseManifestID, repeatNum, i)
 		if hlt.lapi != nil {
-			sid, err := hlt.lapi.CreateStream(manifestID)
+			stream, err := hlt.lapi.CreateStream(livepeer.CreateStreamReq{Name: manifestID})
 			if err != nil {
 				glog.Errorf("Error creating stream using Livepeer API: %v", err)
 				return err
 			}
-			manifestID = sid
+			manifestID = stream.ID
 		}
 		httpIngestURLTemplate := httpIngestURLTemplates[i%len(httpIngestURLTemplates)]
 		httpIngestURL := fmt.Sprintf(httpIngestURLTemplate, manifestID)

--- a/internal/testers/streamer2.go
+++ b/internal/testers/streamer2.go
@@ -108,7 +108,7 @@ func (sr *streamer2) StartStreaming(sourceFileName string, rtmpIngestURL, mediaU
 				if err := test.GlobalErr(); err != nil {
 					if sr.globalError == nil {
 						sr.globalError = err
-						time.AfterFunc(10*time.Second, cancel)
+						time.AfterFunc(waitForTarget, cancel)
 					}
 					errs = append(errs, err.Error())
 				}

--- a/internal/testers/streamer2.go
+++ b/internal/testers/streamer2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -116,6 +117,7 @@ func (sr *streamer2) StartStreaming(sourceFileName string, rtmpIngestURL, mediaU
 				if len(errs) > 0 {
 					msg := errs[0]
 					if len(errs) > 1 {
+						sortErrs(errs)
 						msg = "Multiple errors: " + strings.Join(errs, "; ")
 					}
 					sr.fatalEnd(errors.New(msg))
@@ -148,6 +150,24 @@ func onAnyDone(ctx context.Context, finites []Finite) <-chan Finite {
 		}(f)
 	}
 	return finished
+}
+
+func sortErrs(errs []string) {
+	sortIdx := func(idx int) int {
+		err := strings.ToLower(errs[idx])
+		if strings.Contains(err, "health") {
+			// stream health errs should go last. they're never the root cause when
+			// there are multiple errors.
+			return 1
+		}
+		return 0
+	}
+	sort.Slice(errs, func(idx1, idx2 int) bool {
+		if si1, si2 := sortIdx(idx1), sortIdx(idx2); si1 != si2 {
+			return si1 < si2
+		}
+		return errs[idx1] < errs[idx2]
+	})
 }
 
 // StartPulling pull arbitrary HLS stream and report found errors


### PR DESCRIPTION
 - Allow setting custom `recordObjectStoreId` on API client (pending: porting this change to https://github.com/livepeer/go-api-client/pull/1)
 - Receive the OS ID as a CLI flag and pass it around until the place we actually create the streams