### PR TITLE
feature: mist-api-connector tags per-stream metrics

### DIFF
--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -95,11 +95,11 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 				MediaTimeMs: push.Stats.MediaTime,
 			}
 			if metrics.Bytes > pushInfo.pushedBytes {
-				census.IncMultistreamBytes(metrics.Bytes-pushInfo.pushedBytes, info.id)
+				census.IncMultistreamBytes(metrics.Bytes-pushInfo.pushedBytes, info.stream.PlaybackID) // manifestID === playbackID
 				pushInfo.pushedBytes = metrics.Bytes
 			}
 			if mediaTime := time.Duration(metrics.MediaTimeMs) * time.Millisecond; mediaTime > pushInfo.pushedMediaTime {
-				census.IncMultistreamTime(mediaTime-pushInfo.pushedMediaTime, info.id)
+				census.IncMultistreamTime(mediaTime-pushInfo.pushedMediaTime, info.stream.PlaybackID)
 				pushInfo.pushedMediaTime = mediaTime
 			}
 		}

--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -25,9 +25,6 @@ type metricsCollector struct {
 }
 
 func startMetricsCollector(ctx context.Context, period time.Duration, nodeID, ownRegion string, mapi *mist.API, producer *event.AMQPProducer, amqpExchange string, infop infoProvider) {
-	census.IncMultistreamBytes(0, "")
-	census.IncMultistreamTime(0, "")
-
 	mc := &metricsCollector{nodeID, ownRegion, mapi, producer, amqpExchange, infop}
 	go mc.mainLoop(ctx, period)
 }
@@ -98,11 +95,11 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 				MediaTimeMs: push.Stats.MediaTime,
 			}
 			if metrics.Bytes > pushInfo.pushedBytes {
-				census.IncMultistreamBytes(metrics.Bytes-pushInfo.pushedBytes, info.stream.ID)
+				census.IncMultistreamBytes(metrics.Bytes-pushInfo.pushedBytes, info.id)
 				pushInfo.pushedBytes = metrics.Bytes
 			}
 			if mediaTime := time.Duration(metrics.MediaTimeMs) * time.Millisecond; mediaTime > pushInfo.pushedMediaTime {
-				census.IncMultistreamTime(mediaTime-pushInfo.pushedMediaTime, info.stream.ID)
+				census.IncMultistreamTime(mediaTime-pushInfo.pushedMediaTime, info.id)
 				pushInfo.pushedMediaTime = mediaTime
 			}
 		}

--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -25,8 +25,8 @@ type metricsCollector struct {
 }
 
 func startMetricsCollector(ctx context.Context, period time.Duration, nodeID, ownRegion string, mapi *mist.API, producer *event.AMQPProducer, amqpExchange string, infop infoProvider) {
-	census.IncMultistreamBytes(0)
-	census.IncMultistreamTime(0)
+	census.IncMultistreamBytes(0, "")
+	census.IncMultistreamTime(0, "")
 
 	mc := &metricsCollector{nodeID, ownRegion, mapi, producer, amqpExchange, infop}
 	go mc.mainLoop(ctx, period)
@@ -98,11 +98,11 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 				MediaTimeMs: push.Stats.MediaTime,
 			}
 			if metrics.Bytes > pushInfo.pushedBytes {
-				census.IncMultistreamBytes(metrics.Bytes - pushInfo.pushedBytes)
+				census.IncMultistreamBytes(metrics.Bytes-pushInfo.pushedBytes, info.stream.ID)
 				pushInfo.pushedBytes = metrics.Bytes
 			}
 			if mediaTime := time.Duration(metrics.MediaTimeMs) * time.Millisecond; mediaTime > pushInfo.pushedMediaTime {
-				census.IncMultistreamTime(mediaTime - pushInfo.pushedMediaTime)
+				census.IncMultistreamTime(mediaTime-pushInfo.pushedMediaTime, info.stream.ID)
 				pushInfo.pushedMediaTime = mediaTime
 			}
 		}

--- a/internal/metrics/census.go
+++ b/internal/metrics/census.go
@@ -26,7 +26,7 @@ type (
 		nodeID                string
 		ctx                   context.Context
 		kNodeID               tag.Key
-		kStreamID             tag.Key
+		kManifestID           tag.Key
 		kTrigger              tag.Key
 		kType                 tag.Key
 		mCurrentStreams       *stats.Int64Measure
@@ -71,7 +71,7 @@ func InitCensus(nodeID, version, namespace string) {
 	var err error
 	ctx := context.Background()
 	Census.kNodeID = tag.MustNewKey("node_id")
-	Census.kStreamID = tag.MustNewKey("stream_id")
+	Census.kManifestID = tag.MustNewKey("manifest_id")
 	Census.kTrigger = tag.MustNewKey("trigger")
 	Census.kType = tag.MustNewKey("type")
 	Census.ctx, err = tag.New(ctx, tag.Insert(Census.kNodeID, nodeID))
@@ -156,14 +156,14 @@ func InitCensus(nodeID, version, namespace string) {
 			Name:        "multistream_usage_megabytes",
 			Measure:     Census.mMultistreamUsageMb,
 			Description: "Total number of megabytes multistreamed, or pushed, to external services",
-			TagKeys:     append([]tag.Key{Census.kStreamID}, baseTags...),
+			TagKeys:     append([]tag.Key{Census.kManifestID}, baseTags...),
 			Aggregation: view.Sum(),
 		},
 		{
 			Name:        "multistream_usage_minutes",
 			Measure:     Census.mMultistreamUsageMin,
 			Description: "Total minutes multistreamed, or pushed, to external services",
-			TagKeys:     append([]tag.Key{Census.kStreamID}, baseTags...),
+			TagKeys:     append([]tag.Key{Census.kManifestID}, baseTags...),
 			Aggregation: view.Sum(),
 		},
 		{
@@ -272,8 +272,8 @@ func (cs *censusMetricsCounter) SegmentDownloaded() int64 {
 	return std
 }
 
-func IncMultistreamBytes(bytes int64, streamID string) {
-	ctx, err := tag.New(Census.ctx, tag.Insert(Census.kStreamID, streamID))
+func IncMultistreamBytes(bytes int64, manifestID string) {
+	ctx, err := tag.New(Census.ctx, tag.Insert(Census.kManifestID, manifestID))
 	if err != nil {
 		glog.Error("Error creating context", err)
 		return
@@ -281,8 +281,8 @@ func IncMultistreamBytes(bytes int64, streamID string) {
 	stats.Record(ctx, Census.mMultistreamUsageMb.M(float64(bytes)/1024/1024))
 }
 
-func IncMultistreamTime(mediaTime time.Duration, streamID string) {
-	ctx, err := tag.New(Census.ctx, tag.Insert(Census.kStreamID, streamID))
+func IncMultistreamTime(mediaTime time.Duration, manifestID string) {
+	ctx, err := tag.New(Census.ctx, tag.Insert(Census.kManifestID, manifestID))
 	if err != nil {
 		glog.Error("Error creating context", err)
 		return

--- a/internal/metrics/census.go
+++ b/internal/metrics/census.go
@@ -26,6 +26,7 @@ type (
 		nodeID                string
 		ctx                   context.Context
 		kNodeID               tag.Key
+		kStreamID             tag.Key
 		kTrigger              tag.Key
 		kType                 tag.Key
 		mCurrentStreams       *stats.Int64Measure
@@ -70,6 +71,7 @@ func InitCensus(nodeID, version, namespace string) {
 	var err error
 	ctx := context.Background()
 	Census.kNodeID = tag.MustNewKey("node_id")
+	Census.kStreamID = tag.MustNewKey("stream_id")
 	Census.kTrigger = tag.MustNewKey("trigger")
 	Census.kType = tag.MustNewKey("type")
 	Census.ctx, err = tag.New(ctx, tag.Insert(Census.kNodeID, nodeID))
@@ -154,14 +156,14 @@ func InitCensus(nodeID, version, namespace string) {
 			Name:        "multistream_usage_megabytes",
 			Measure:     Census.mMultistreamUsageMb,
 			Description: "Total number of megabytes multistreamed, or pushed, to external services",
-			TagKeys:     baseTags,
+			TagKeys:     append([]tag.Key{Census.kStreamID}, baseTags...),
 			Aggregation: view.Sum(),
 		},
 		{
 			Name:        "multistream_usage_minutes",
 			Measure:     Census.mMultistreamUsageMin,
 			Description: "Total minutes multistreamed, or pushed, to external services",
-			TagKeys:     baseTags,
+			TagKeys:     append([]tag.Key{Census.kStreamID}, baseTags...),
 			Aggregation: view.Sum(),
 		},
 		{
@@ -270,12 +272,22 @@ func (cs *censusMetricsCounter) SegmentDownloaded() int64 {
 	return std
 }
 
-func IncMultistreamBytes(bytes int64) {
-	stats.Record(Census.ctx, Census.mMultistreamUsageMb.M(float64(bytes)/1024/1024))
+func IncMultistreamBytes(bytes int64, streamID string) {
+	ctx, err := tag.New(Census.ctx, tag.Insert(Census.kStreamID, streamID))
+	if err != nil {
+		glog.Error("Error creating context", err)
+		return
+	}
+	stats.Record(ctx, Census.mMultistreamUsageMb.M(float64(bytes)/1024/1024))
 }
 
-func IncMultistreamTime(mediaTime time.Duration) {
-	stats.Record(Census.ctx, Census.mMultistreamUsageMin.M(mediaTime.Minutes()))
+func IncMultistreamTime(mediaTime time.Duration, streamID string) {
+	ctx, err := tag.New(Census.ctx, tag.Insert(Census.kStreamID, streamID))
+	if err != nil {
+		glog.Error("Error creating context", err)
+		return
+	}
+	stats.Record(ctx, Census.mMultistreamUsageMin.M(mediaTime.Minutes()))
 }
 
 // CurrentStreams set number of active streams


### PR DESCRIPTION
* This change adds streamID tags to the `multistream_usage_megabytes` `multistream_usage_minutes` metrics of mist-api-connector service

Testing:
compiles with `make connector`

Issue:
https://app.zenhub.com/workspaces/video-user-team-5dd2c75e4ee08500015994d7/issues/livepeer/go-livepeer/2172