### PR TITLE
recordtester: Add ingest arg to skip LP /api/ingest

### DIFF
--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -249,7 +249,13 @@ func main() {
 	} else if *continuousTest > 0 {
 		metricServer := server.NewMetricsServer()
 		go metricServer.Start(gctx, *bind)
-		crt := recordtester.NewContinuousRecordTester(gctx, *pagerDutyIntegrationKey, *pagerDutyComponent, *pagerDutyLowUrgency, rtOpts)
+		crtOpts := recordtester.ContinuousRecordTesterOptions{
+			PagerDutyIntegrationKey: *pagerDutyIntegrationKey,
+			PagerDutyComponent:      *pagerDutyComponent,
+			PagerDutyLowUrgency:     *pagerDutyLowUrgency,
+			RecordTesterOptions:     rtOpts,
+		}
+		crt := recordtester.NewContinuousRecordTester(gctx, crtOpts)
 		err := crt.Start(fileName, *testDuration, *pauseDuration, *continuousTest)
 		if err != nil {
 			glog.Warningf("Continuous test ended with err=%v", err)

--- a/internal/app/recordtester/continuous_record_tester.go
+++ b/internal/app/recordtester/continuous_record_tester.go
@@ -25,6 +25,13 @@ type (
 		Done() <-chan struct{}
 	}
 
+	ContinuousRecordTesterOptions struct {
+		PagerDutyIntegrationKey string
+		PagerDutyComponent      string
+		PagerDutyLowUrgency     bool
+		RecordTesterOptions
+	}
+
 	continuousRecordTester struct {
 		ctx                     context.Context
 		cancel                  context.CancelFunc
@@ -42,18 +49,18 @@ type (
 )
 
 // NewContinuousRecordTester returns new object
-func NewContinuousRecordTester(gctx context.Context, pagerDutyIntegrationKey, pagerDutyComponent string, pagerDutyLowUrgency bool, rtOpts RecordTesterOptions) IContinuousRecordTester {
+func NewContinuousRecordTester(gctx context.Context, opts ContinuousRecordTesterOptions) IContinuousRecordTester {
 	ctx, cancel := context.WithCancel(gctx)
-	server := rtOpts.API.GetServer()
+	server := opts.API.GetServer()
 	u, _ := url.Parse(server)
 	crt := &continuousRecordTester{
 		ctx:                     ctx,
 		cancel:                  cancel,
 		host:                    u.Host,
-		pagerDutyIntegrationKey: pagerDutyIntegrationKey,
-		pagerDutyComponent:      pagerDutyComponent,
-		pagerDutyLowUrgency:     pagerDutyLowUrgency,
-		rtOpts:                  rtOpts,
+		pagerDutyIntegrationKey: opts.PagerDutyIntegrationKey,
+		pagerDutyComponent:      opts.PagerDutyComponent,
+		pagerDutyLowUrgency:     opts.PagerDutyLowUrgency,
+		rtOpts:                  opts.RecordTesterOptions,
 	}
 	return crt
 }

--- a/internal/app/recordtester/continuous_record_tester.go
+++ b/internal/app/recordtester/continuous_record_tester.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strconv"
 	"time"
 
@@ -66,8 +65,7 @@ func NewContinuousRecordTester(gctx context.Context, opts ContinuousRecordTester
 }
 
 func (crt *continuousRecordTester) Start(fileName string, testDuration, pauseDuration, pauseBetweenTests time.Duration) error {
-	hostname, _ := os.Hostname()
-	messenger.SendMessage(fmt.Sprintf("Starting continuous test of %s on hostname=%s", crt.host, hostname))
+	messenger.SendMessage(fmt.Sprintf("Starting continuous test of %s", crt.host))
 	try := 0
 	notRtmpTry := 0
 	maxTestDuration := 2*testDuration + pauseDuration + 15*time.Minute

--- a/internal/app/recordtester/continuous_record_tester.go
+++ b/internal/app/recordtester/continuous_record_tester.go
@@ -35,6 +35,7 @@ type (
 		pagerDutyIntegrationKey string
 		pagerDutyComponent      string
 		pagerDutyLowUrgency     bool
+		ingest                  *livepeer.Ingest
 		useHTTP                 bool
 		mp4                     bool
 		streamHealth            bool
@@ -47,7 +48,7 @@ type (
 )
 
 // NewContinuousRecordTester returns new object
-func NewContinuousRecordTester(gctx context.Context, lapi *livepeer.API, lanalyzers testers.AnalyzerByRegion, pagerDutyIntegrationKey, pagerDutyComponent string, pagerDutyLowUrgency bool, useHTTP, mp4, streamHealth bool) IContinuousRecordTester {
+func NewContinuousRecordTester(gctx context.Context, lapi *livepeer.API, lanalyzers testers.AnalyzerByRegion, pagerDutyIntegrationKey, pagerDutyComponent string, pagerDutyLowUrgency bool, ingest *livepeer.Ingest, useHTTP, mp4, streamHealth bool) IContinuousRecordTester {
 	ctx, cancel := context.WithCancel(gctx)
 	server := lapi.GetServer()
 	u, _ := url.Parse(server)
@@ -60,6 +61,7 @@ func NewContinuousRecordTester(gctx context.Context, lapi *livepeer.API, lanalyz
 		pagerDutyIntegrationKey: pagerDutyIntegrationKey,
 		pagerDutyComponent:      pagerDutyComponent,
 		pagerDutyLowUrgency:     pagerDutyLowUrgency,
+		ingest:                  ingest,
 		useHTTP:                 useHTTP,
 		mp4:                     mp4,
 		streamHealth:            streamHealth,
@@ -78,7 +80,7 @@ func (crt *continuousRecordTester) Start(fileName string, testDuration, pauseDur
 		messenger.SendMessage(msg)
 
 		ctx, cancel := context.WithTimeout(crt.ctx, maxTestDuration)
-		rt := NewRecordTester(ctx, crt.lapi, crt.lanalyzers, true, crt.useHTTP, crt.mp4, crt.streamHealth)
+		rt := NewRecordTester(ctx, crt.lapi, crt.lanalyzers, crt.ingest, true, crt.useHTTP, crt.mp4, crt.streamHealth)
 		es, err := rt.Start(fileName, testDuration, pauseDuration)
 		rt.Clean()
 		ctxErr := ctx.Err()

--- a/internal/app/recordtester/continuous_record_tester.go
+++ b/internal/app/recordtester/continuous_record_tester.go
@@ -81,7 +81,7 @@ func (crt *continuousRecordTester) Start(fileName string, testDuration, pauseDur
 		cancel()
 
 		if crt.ctx.Err() != nil {
-			messenger.SendMessage(fmt.Sprintf("Continuous record test of %s cancelled on hostname=%s", crt.host, hostname))
+			messenger.SendMessage(fmt.Sprintf("Continuous record test of %s cancelled", crt.host))
 			return crt.ctx.Err()
 		} else if ctxErr != nil {
 			msg := fmt.Sprintf("Record test of %s timed out, potential deadlock! ctxErr=%q err=%q", crt.host, ctxErr, err)
@@ -119,7 +119,7 @@ func (crt *continuousRecordTester) Start(fileName string, testDuration, pauseDur
 		glog.Infof("Waiting %s before next test", pauseBetweenTests)
 		select {
 		case <-crt.ctx.Done():
-			messenger.SendMessage(fmt.Sprintf("Continuous record test of %s cancelled on hostname=%s", crt.host, hostname))
+			messenger.SendMessage(fmt.Sprintf("Continuous record test of %s cancelled", crt.host))
 			return err
 		case <-time.After(pauseBetweenTests):
 		}

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -32,6 +32,17 @@ type (
 		Stream() *livepeer.CreateStreamResp
 	}
 
+	RecordTesterOptions struct {
+		*livepeer.API
+		Analyzers        testers.AnalyzerByRegion
+		Ingest           *livepeer.Ingest
+		VODStats         model.VODStats
+		UseForceURL      bool
+		UseHTTP          bool
+		TestMP4          bool
+		TestStreamHealth bool
+	}
+
 	recordTester struct {
 		lapi         *livepeer.API
 		lanalyzers   testers.AnalyzerByRegion
@@ -84,18 +95,18 @@ var standardProfiles = []livepeer.Profile{
 }
 
 // NewRecordTester ...
-func NewRecordTester(gctx context.Context, lapi *livepeer.API, lanalyzers testers.AnalyzerByRegion, ingest *livepeer.Ingest, useForceURL, useHTTP, mp4, streamHealth bool) IRecordTester {
+func NewRecordTester(gctx context.Context, opts RecordTesterOptions) IRecordTester {
 	ctx, cancel := context.WithCancel(gctx)
 	rt := &recordTester{
-		lapi:         lapi,
-		lanalyzers:   lanalyzers,
-		ingest:       ingest,
-		useForceURL:  useForceURL,
+		lapi:         opts.API,
+		lanalyzers:   opts.Analyzers,
+		ingest:       opts.Ingest,
+		useForceURL:  opts.UseForceURL,
 		ctx:          ctx,
 		cancel:       cancel,
-		useHTTP:      useHTTP,
-		mp4:          mp4,
-		streamHealth: streamHealth,
+		useHTTP:      opts.UseHTTP,
+		mp4:          opts.TestMP4,
+		streamHealth: opts.TestStreamHealth,
 	}
 	return rt
 }

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -6,8 +6,10 @@ package messenger
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -300,6 +302,8 @@ func sendLoop() {
 	}
 }
 
+var hostname, _ = os.Hostname()
+
 func sendMessage(msg string) {
 	if len(msg) > maxMessageLen {
 		for {
@@ -316,6 +320,7 @@ func sendMessage(msg string) {
 		}
 		return
 	}
+	msg = fmt.Sprintf("%s: %s", hostname, msg)
 	sendRawMessage(encodeMessage(msg))
 }
 
@@ -323,23 +328,6 @@ func sendRawMessage(msg []byte) {
 	if webhookURL == "" || msgCh == nil {
 		return
 	}
-	/*
-		if len(msg) > maxMessageLen {
-			for {
-				l := maxMessageLen - 10
-				if l > len(msg) {
-					l = len(msg)
-				}
-				msg1 := msg[:l]
-				msg = msg[l:]
-				sendMessage(msg1)
-				if len(msg) == 0 {
-					break
-				}
-			}
-			return
-		}
-	*/
 	msgCh <- msg
 }
 

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -320,7 +320,7 @@ func sendMessage(msg string) {
 		}
 		return
 	}
-	msg = fmt.Sprintf("%s: %s", hostname, msg)
+	msg = fmt.Sprintf("`[%s]` %s", hostname, msg)
 	sendRawMessage(encodeMessage(msg))
 }
 


### PR DESCRIPTION
That API now returns the global ingest and we don't want that.
We should instead stream into the region being tested and so
the best way for that should be receiving an explicit argument
instead, since we don't want to expose the regional URLs in any
way to our users.