### PR TITLE
mapic: Added triggerUserNew

### DIFF
--- a/apis/livepeer/livepeer.go
+++ b/apis/livepeer/livepeer.go
@@ -462,11 +462,11 @@ func (lapi *API) DefaultPresets() []string {
 }
 
 // GetWebhooksForEvent gets webhooks for an event by user id
-func (lapi *API) GetWebhooksForEvent(userId string, event string) ([]UserWebhook, error) {
+func (lapi *API) GetWebhooksForEvent(userId string, streamId string, event string) ([]UserWebhook, error) {
 	if userId == "" || event == "" {
 		return nil, fmt.Errorf("userId and event must be specified")
 	}
-	u := fmt.Sprintf("%s/api/webhook/subscribed/%s?userId=%s", lapi.choosenServer, event, userId)
+	u := fmt.Sprintf("%s/api/webhook/subscribed/%s?userId=%s&streamId=%s", lapi.choosenServer, event, userId, streamId)
 	return lapi.GetWebhooks(u)
 }
 

--- a/apis/livepeer/livepeer.go
+++ b/apis/livepeer/livepeer.go
@@ -134,21 +134,34 @@ type (
 
 	// User Webhooks
 	UserWebhook struct {
-		ID           string        `json:"id,omitempty"`
-		Url          string        `json:"url,omitempty"`
-		Kind         string        `json:"kind,omitempty"`
-		Name         string        `json:"name,omitempty"`
-		Events       []string      `json:"events,omitempty"`
-		UserID       string        `json:"userId,omitempty"`
-		CreatedAt    int64         `json:"createdAt,omitempty"`
-		SharedSecret string        `json:"sharedSecret,omitempty"`
-		Status       WebhookStatus `json:"status,omitempty"`
+		ID           string   `json:"id,omitempty"`
+		Url          string   `json:"url,omitempty"`
+		Kind         string   `json:"kind,omitempty"`
+		Name         string   `json:"name,omitempty"`
+		Events       []string `json:"events,omitempty"`
+		UserID       string   `json:"userId,omitempty"`
+		CreatedAt    int64    `json:"createdAt,omitempty"`
+		SharedSecret string   `json:"sharedSecret,omitempty"`
 	}
 
-	// Webhooks status
-	WebhookStatus struct {
-		LastTriggeredAt int64                  `json:"lastTriggeredAt,omitempty"`
-		LastFailure     map[string]interface{} `json:"lastFailure,omitempty"`
+	WebhookUpdateStatusRequest struct {
+		ErrorMessage string                `json:"errorMessage,omitempty"`
+		Response     WebhookResponseStatus `json:"response,omitempty"`
+	}
+
+	WebhookResponseStatus struct {
+		ID         string          `json:"webhookId,omitempty"`
+		CreatedAt  int64           `json:"createdAt,omitempty"`
+		StatusCode int             `json:"statusCode,omitempty"`
+		Response   WebhookResponse `json:"response,omitempty"`
+	}
+
+	WebhookResponse struct {
+		Body       string            `json:"body"`
+		Status     int               `json:"status,omitempty"`
+		Headers    map[string]string `json:"headers,omitempty"`
+		Redirected bool              `json:"redirected,omitempty"`
+		StatusText string            `json:"statusText,omitempty"`
 	}
 
 	MultistreamTarget struct {
@@ -478,9 +491,8 @@ func (lapi *API) GetWebhooksForEvent(userId string, streamId string, event strin
 }
 
 // Update webhook status & response
-func (lapi *API) UpdateWebhookStatus(id string, status map[string]interface{}) bool {
+func (lapi *API) UpdateWebhookAsync(id string, status WebhookUpdateStatusRequest) {
 	go lapi.UpdateWebhook(id, status)
-	return true
 }
 
 // GetStreamByKey gets stream by streamKey
@@ -833,7 +845,7 @@ func (lapi *API) GetWebhooks(u string) ([]UserWebhook, error) {
 	return r, nil
 }
 
-func (lapi *API) UpdateWebhook(id string, status map[string]interface{}) error {
+func (lapi *API) UpdateWebhook(id string, status WebhookUpdateStatusRequest) error {
 	rType := "update_webhook"
 	start := time.Now()
 	u := fmt.Sprintf("%s/api/webhook/%s/status", lapi.choosenServer, id)

--- a/apis/livepeer/livepeer.go
+++ b/apis/livepeer/livepeer.go
@@ -461,8 +461,8 @@ func (lapi *API) DefaultPresets() []string {
 	return lapi.presets
 }
 
-// GetWebhooksByUserId gets webhooks by user id
-func (lapi *API) GetWebhooksByUserId(userId string, event string) ([]UserWebhook, error) {
+// GetWebhooksForEvent gets webhooks for an event by user id
+func (lapi *API) GetWebhooksForEvent(userId string, event string) ([]UserWebhook, error) {
 	if userId == "" || event == "" {
 		return nil, fmt.Errorf("userId and event must be specified")
 	}

--- a/cmd/mist-api-connector/mist-api-connector.go
+++ b/cmd/mist-api-connector/mist-api-connector.go
@@ -42,6 +42,7 @@ func main() {
 	sendAudio := fs.String("send-audio", "record", "when should we send audio?  {always|never|record}")
 	apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used by the Mist server")
 	apiServer := fs.String("api-server", livepeer.ACServer, "Livepeer API server to use")
+	disableTrigger:= fs.String("disable-trigger", "", "Disable trigger for Mist server e.g 'USER_NEW'")
 	routePrefix := fs.String("route-prefix", "", "Prefix to be prepended to all created routes e.g. 'nyc-'")
 	playbackDomain := fs.String("playback-domain", "", "regex of domain to create routes for (ex: playback.livepeer.live)")
 	mistURL := fs.String("route-mist-url", "", "external URL of this Mist instance (used for routing) (ex: https://mist-server-0.livepeer.live)")
@@ -111,6 +112,7 @@ func main() {
 		MistURL:        *mistURL,
 		BaseStreamName: *baseStreamName,
 		CheckBandwidth: false,
+		DisableTrigger: *disableTrigger,
 		SendAudio:      *sendAudio,
 		EtcdEndpoints:  etcdEndpoints,
 		EtcdCaCert:     *etcdCaCert,

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -94,13 +94,18 @@ type (
 		startedAt          time.Time
 	}
 
-	userNewPayload struct {
-		StreamName     string `json:"streamName"`
-		IpAddress      string `json:"ipAddress"`
-		Timestamp      int64  `json:"timestamp"`
-		OutputProtocol string `json:"outputProtocol"`
-		RequestUrl     string `json:"requestUrl"`
-		SessionID      string `json:"sessionID"`
+	userNewHook struct {
+		// StreamName     string `json:"streamName"`
+		// IpAddress      string `json:"ipAddress"`
+		Timestamp int64 `json:"timestamp"`
+		// OutputProtocol string `json:"outputProtocol"`
+		// RequestUrl     string `json:"requestUrl"`
+		// SessionID      string `json:"sessionID"`
+		Payload userNewHookPayload `json:"payload"`
+	}
+
+	userNewHookPayload struct {
+		RequestUrl string `json:"requestUrl"`
 	}
 
 	trackListDesc struct {
@@ -503,13 +508,15 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 
 	timestamp := time.Now().Unix()
 
-	u := &userNewPayload{
-		StreamName:     lines[0],
-		IpAddress:      lines[1],
-		Timestamp:      timestamp,
-		OutputProtocol: lines[3],
-		RequestUrl:     lines[4],
-		SessionID:      lines[5],
+	u := &userNewHook{
+		Timestamp: timestamp,
+		Payload: userNewHookPayload{
+			RequestUrl: lines[4],
+		},
+		// StreamName:     lines[0],
+		// IpAddress:      lines[1],
+		// OutputProtocol: lines[3],
+		// SessionID:      lines[5],
 	}
 
 	b, err := json.Marshal(u)

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -568,18 +568,10 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 			return true
 		}
 
-		req := &http.Request{
-			Method: "POST",
-			Header: http.Header{
-				"Content-Type": []string{"application/json"},
-			},
-			Body: ioutil.NopCloser(strings.NewReader(payload)),
-		}
-
-		req.URL, err = url.Parse(userWebhook.Url)
-
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, userWebhook.Url, strings.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
 		if err != nil {
-			glog.Errorf("Error parsing URL %s for user webhook %s err=%v", userWebhook.Url, userWebhook.ID, err)
+			glog.Errorf("Error creating request to url=%q webhookId=%s err=%q", userWebhook.Url, userWebhook.ID, err)
 			return false
 		}
 

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -491,7 +491,7 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 	}
 
 	userId := stream.UserID
-	userWebhooks, err := mc.lapi.GetWebhooksByUserId(userId, "user.new")
+	userWebhooks, err := mc.lapi.GetWebhooksByUserId(userId, "playback.user.new")
 	if err != nil {
 		glog.Errorf("Error getting webhooks for user %s err=%v", userId, err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -500,7 +500,7 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 	}
 
 	if len(userWebhooks) == 0 {
-		glog.V(model.DEBUG).Infof("No user.new webhooks for user %s", userId)
+		glog.V(model.DEBUG).Infof("No playback.user.new webhooks for user %s", userId)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("false"))
 		return false
@@ -511,11 +511,11 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 			glog.Errorf("User webhook %s has no URL", userWebhook.ID)
 			continue
 		}
-		glog.V(model.DEBUG).Infof("Calling user.new webhook %s", userWebhook.Url)
+		glog.V(model.DEBUG).Infof("Calling playback.user.new webhook %s", userWebhook.Url)
 
 		resp, err := http.Post(userWebhook.Url, "text/plain", strings.NewReader(rawRequest))
 		if err != nil {
-			glog.Errorf("Error calling user.new webhook %s err=%v", userWebhook.Url, err)
+			glog.Errorf("Error calling playback.user.new webhook %s err=%v", userWebhook.Url, err)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("false"))
 			return false
@@ -523,20 +523,20 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			glog.Errorf("Error reading response body from user.new webhook %s err=%v", userWebhook.Url, err)
+			glog.Errorf("Error reading response body from playback.user.new webhook %s err=%v", userWebhook.Url, err)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("false"))
 			return false
 		}
 
 		if resp.StatusCode/100 != 2 {
-			glog.Errorf("Error calling user.new webhook %s status code=%d body=%s", userWebhook.Url, resp.StatusCode, string(body))
+			glog.Errorf("Error calling playback.user.new webhook %s status code=%d body=%s", userWebhook.Url, resp.StatusCode, string(body))
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("false"))
 			return false
 		}
 
-		glog.V(model.DEBUG).Infof("Response from user.new webhook %s: %s", userWebhook.Url, string(body))
+		glog.V(model.DEBUG).Infof("Response from playback.user.new webhook %s: %s", userWebhook.Url, string(body))
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -543,7 +543,7 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 	if len(userWebhooks) == 0 {
 		glog.V(model.DEBUG).Infof("No playback.user.new webhooks for user %s", userId)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("false"))
+		w.Write([]byte("true"))
 		return false
 	}
 	

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -129,13 +129,14 @@ type (
 		Height   int    `json:"height,omitempty"`
 	}
 
-	// MacOptions configuration object
+	// MacOptions configuration objboolect
 	MacOptions struct {
 		NodeID, MistHost string
 		MistAPI          *mist.API
 		LivepeerAPI      *livepeer.API
 		BalancerHost     string
 		CheckBandwidth   bool
+		DisableTrigger   string
 		RoutePrefix, PlaybackDomain, MistURL,
 		SendAudio, BaseStreamName string
 		EtcdEndpoints                 []string
@@ -156,6 +157,7 @@ type (
 		mu             sync.RWMutex
 		mistHot        string
 		checkBandwidth bool
+		disableTrigger string
 		routePrefix    string
 		mistURL        string
 		playbackDomain string
@@ -256,6 +258,7 @@ func NewMac(opts MacOptions) (IMac, error) {
 		mapi:           opts.MistAPI,
 		lapi:           opts.LivepeerAPI,
 		checkBandwidth: opts.CheckBandwidth,
+		disableTrigger: opts.DisableTrigger,
 		balancerHost:   opts.BalancerHost,
 		// pub2id:         make(map[string]string), // public key to stream id
 		pub2info:       make(map[string]*streamInfo), // public key to info
@@ -1259,7 +1262,9 @@ func (mc *mac) SetupTriggers(ownURI string) error {
 	added = mc.addTrigger(triggers, "LIVE_TRACK_LIST", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "PUSH_OUT_START", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "PUSH_END", ownURI, "", "", false) || added
-	added = mc.addTrigger(triggers, "USER_NEW", ownURI, "", "", true) || added
+	if mc.disableTrigger != "USER_NEW" {
+		added = mc.addTrigger(triggers, "USER_NEW", ownURI, "", "", true) || added
+	}
 	if added {
 		err = mc.mapi.SetTriggers(triggers)
 	}

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -1259,6 +1259,7 @@ func (mc *mac) SetupTriggers(ownURI string) error {
 	added = mc.addTrigger(triggers, "LIVE_TRACK_LIST", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "PUSH_OUT_START", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "PUSH_END", ownURI, "", "", false) || added
+	added = mc.addTrigger(triggers, "USER_NEW", ownURI, "", "", true) || added
 	if added {
 		err = mc.mapi.SetTriggers(triggers)
 	}

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -530,16 +530,16 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 	payload := string(b)
 
 	playbackId := lines[0]
-	stream, err := mc.lapi.GetStreamByPlaybackID(playbackId)
-	if err != nil || stream == nil {
-		glog.Errorf("Error getting stream info from Livepeer API playbackId=%s err=%v", playbackId, err)
+	info := mc.getStreamInfo(playbackId)
+	if info == nil {
+		glog.Errorf("Error getting stream info from streamInfo playbackId=%s err=%v", playbackId, err)
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("false"))
 		return false
-	}
+	} 
+	userId := info.stream.UserID
 
-	userId := stream.UserID
-	userWebhooks, err := mc.lapi.GetWebhooksByUserId(userId, "playback.user.new")
+	userWebhooks, err := mc.lapi.GetWebhooksForEvent(userId, "playback.user.new")
 	if err != nil {
 		glog.Errorf("Error getting webhooks for user %s err=%v", userId, err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -540,7 +540,7 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("false"))
 		return false
-	} 
+	}
 	userId := info.stream.UserID
 	userWebhooks := info.userNewHooks
 
@@ -686,15 +686,15 @@ func (mc *mac) triggerPushRewrite(w http.ResponseWriter, r *http.Request, lines 
 			mc.removeInfo(stream.PlaybackID)
 		}
 
-		userNewHooks, err := mc.lapi.GetWebhooksForEvent(stream.UserID, "playback.user.new")
+		userNewHooks, err := mc.lapi.GetWebhooksForEvent(stream.UserID, stream.ID, "playback.user.new")
 
 		mc.pub2info[stream.PlaybackID] = &streamInfo{
-			id:         	stream.ID,
-			stream:     	stream,
-			done:       	make(chan struct{}),
-			pushStatus: 	make(map[string]*pushStatus),
-			startedAt:  	time.Now(),
-			userNewHooks: 	userNewHooks,
+			id:           stream.ID,
+			stream:       stream,
+			done:         make(chan struct{}),
+			pushStatus:   make(map[string]*pushStatus),
+			startedAt:    time.Now(),
+			userNewHooks: userNewHooks,
 		}
 
 		streamKey = stream.PlaybackID

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -61,6 +61,15 @@ const eventMultistreamDisconnected = "multistream.disconnected"
 
 var playbackPrefixes = []string{"hls", "cmaf"}
 
+var webhookClient = &http.Client{
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) > 2 {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	},
+}
+
 type (
 	// IMac creates new Mist API Connector application
 	IMac interface {
@@ -581,7 +590,7 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 			req.Header.Add("Livepeer-Signature", signature_header)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := webhookClient.Do(req)
 		webhookStatus := livepeer.WebhookUpdateStatusRequest{
 			Response: livepeer.WebhookResponseStatus{
 				ID:        userWebhook.ID,

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -548,10 +548,10 @@ func (mc *mac) triggerUserNew(w http.ResponseWriter, r *http.Request, lines []st
 	}
 
 	if len(userWebhooks) == 0 {
-		glog.V(model.DEBUG).Infof("No playback.user.new webhooks for user %s", userId)
+		glog.V(model.VVERBOSE).Infof("No playback.user.new webhooks for user %s", userId)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
-		return false
+		return true
 	}
 
 	for _, userWebhook := range userWebhooks {

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -129,7 +129,7 @@ type (
 		Height   int    `json:"height,omitempty"`
 	}
 
-	// MacOptions configuration objboolect
+	// MacOptions configuration object
 	MacOptions struct {
 		NodeID, MistHost string
 		MistAPI          *mist.API


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Catches USER_NEW trigger from Mist and call the user configured webhooks on the user.new event (probably to be renamed).
Currently it responds `false` to Mist if one or more webhooks fail.
Depends on [#995](https://github.com/livepeer/livepeer-com/pull/995) and [#994](https://github.com/livepeer/livepeer-com/pull/994).

**Specific updates (required)**

- Added triggerUserNew
- Added UserWebhook struct to `lapi`
- Added GetWebhooksByUserId on `lapi`

**How did you test each of these updates (required)**

livepeer-in-a-nice-box
