### PR TITLE
Add orchestrator summary log

### DIFF
--- a/cmd/orch-tester/orch_tester.go
+++ b/cmd/orch-tester/orch_tester.go
@@ -123,7 +123,6 @@ func main() {
 	refreshWait := 70 * time.Second
 
 	var summary statsSummary
-	var postStatsCount int
 	start = time.Now()
 
 	for _, o := range orchestrators {
@@ -226,7 +225,6 @@ func main() {
 			glog.Error(err)
 			continue
 		}
-		postStatsCount++
 		summary.add(apiStats)
 
 		// if we haven't found a random sample by now cancel and wait for the backup attempt to complete before returning
@@ -239,7 +237,6 @@ func main() {
 			continue
 		}
 	}
-	glog.Infof("Posted stats count: %v", postStatsCount)
 	summary.log()
 }
 
@@ -839,22 +836,16 @@ type statsSummary struct {
 }
 
 func (s *statsSummary) add(stats *apiModels.Stats) {
-	glog.Infof("Adding stats SuccessRate %v", stats.SuccessRate)
-	fmt.Printf("Adding stats SuccessRate %v\n", stats.SuccessRate)
 	if stats.SuccessRate >= minSanityCheckSuccessRate {
-		glog.Infof("Good success rate")
 		s.sanityCheckSuccessRateCount++
 	}
-	glog.Infof("Adding stats RoundTripTime %v", stats.RoundTripTime)
 	if stats.RoundTripTime <= maxSanityCheckRoundTripTime {
-		glog.Infof("Good round trip time")
 		s.sanityCheckRoundTripTimeCount++
 	}
 }
 
 func (s *statsSummary) log() {
-	glog.Infof("Completed the orch-tester job, number of orchestrators with success rate higher than %v: %v, number of orchestrators with round trip time lower than %v: %v", minSanityCheckSuccessRate, s.sanityCheckRoundTripTimeCount, maxSanityCheckRoundTripTime, s.sanityCheckRoundTripTimeCount)
-	glog.Warning("Check warning!!!")
+	glog.Infof("Completed the orch-tester job, number of orchestrators with success rate higher than %v: %v, number of orchestrators with round trip time lower than %v: %v", minSanityCheckSuccessRate, s.sanityCheckSuccessRateCount, maxSanityCheckRoundTripTime, s.sanityCheckRoundTripTimeCount)
 	if s.sanityCheckSuccessRateCount < minSanityCheckOrchestratorCount || s.sanityCheckRoundTripTimeCount < minSanityCheckOrchestratorCount {
 		glog.Warning("Low number of orchestrators which passed the sanity check, please make sure that the orch-tester job is configured correctly")
 	}

--- a/cmd/orch-tester/orch_tester.go
+++ b/cmd/orch-tester/orch_tester.go
@@ -122,6 +122,7 @@ func main() {
 
 	refreshWait := 70 * time.Second
 
+	var summary statsSummary
 	start = time.Now()
 
 	for _, o := range orchestrators {
@@ -220,6 +221,7 @@ func main() {
 		}
 		apiStats.Errors = errors
 
+		summary.add(apiStats)
 		if err := streamer.postStats(apiStats); err != nil {
 			glog.Error(err)
 			continue
@@ -235,6 +237,7 @@ func main() {
 			continue
 		}
 	}
+	summary.log()
 }
 
 func validateURL(addr string) (string, error) {
@@ -819,4 +822,37 @@ func (s *streamerClient) downloadMediaPlaylist(uri string) (*m3u8.MediaPlaylist,
 	}
 	pl := gpl.(*m3u8.MediaPlaylist)
 	return pl, nil
+}
+
+const (
+	minSanityCheckSuccessRate       = 0.8
+	maxSanityCheckRoundTripTime     = 2.0
+	minSanityCheckOrchestratorCount = 20
+)
+
+type statsSummary struct {
+	sanityCheckSuccessRateCount   int
+	sanityCheckRoundTripTimeCount int
+}
+
+func (s *statsSummary) add(stats *apiModels.Stats) {
+	glog.Infof("Adding stats SuccessRate %v", stats.SuccessRate)
+	fmt.Printf("Adding stats SuccessRate %v\n", stats.SuccessRate)
+	if stats.SuccessRate >= minSanityCheckSuccessRate {
+		glog.Infof("Good success rate")
+		s.sanityCheckSuccessRateCount++
+	}
+	glog.Infof("Adding stats RoundTripTime %v", stats.RoundTripTime)
+	if stats.RoundTripTime <= maxSanityCheckRoundTripTime {
+		glog.Infof("Good round trip time")
+		s.sanityCheckRoundTripTimeCount++
+	}
+}
+
+func (s *statsSummary) log() {
+	glog.Infof("Completed the orch-tester job, number of orchestrators with success rate higher than %v: %v, number of orchestrators with round trip time lower than %v: %v", minSanityCheckSuccessRate, s.sanityCheckRoundTripTimeCount, maxSanityCheckRoundTripTime, s.sanityCheckRoundTripTimeCount)
+	glog.Warning("Check warning!!!")
+	if s.sanityCheckSuccessRateCount < minSanityCheckOrchestratorCount || s.sanityCheckRoundTripTimeCount < minSanityCheckOrchestratorCount {
+		glog.Warning("Low number of orchestrators which passed the sanity check, please make sure that the orch-tester job is configured correctly")
+	}
 }

--- a/cmd/orch-tester/orch_tester.go
+++ b/cmd/orch-tester/orch_tester.go
@@ -123,6 +123,7 @@ func main() {
 	refreshWait := 70 * time.Second
 
 	var summary statsSummary
+	var postStatsCount int
 	start = time.Now()
 
 	for _, o := range orchestrators {
@@ -221,11 +222,12 @@ func main() {
 		}
 		apiStats.Errors = errors
 
-		summary.add(apiStats)
 		if err := streamer.postStats(apiStats); err != nil {
 			glog.Error(err)
 			continue
 		}
+		postStatsCount++
+		summary.add(apiStats)
 
 		// if we haven't found a random sample by now cancel and wait for the backup attempt to complete before returning
 		if *randomSample {
@@ -237,6 +239,7 @@ func main() {
 			continue
 		}
 	}
+	glog.Infof("Posted stats count: %v", postStatsCount)
 	summary.log()
 }
 


### PR DESCRIPTION
Adds a summary for the orch-tester job.

It logs a warning if more less than best 20 Os:
- either had success rate < 80%
- or round trip time over 1.0