### PR TITLE
segmenter: Fix error handling 

### DIFF
--- a/cmd/api-transcoder/api-transcoder.go
+++ b/cmd/api-transcoder/api-transcoder.go
@@ -205,7 +205,7 @@ func transcode(apiKey, apiHost, src, dst string, presets []string, lprofile *liv
 		}
 	}
 	for _, outFile := range outFiles {
-		if err = outFile.Close(); err != nil {
+		if err := outFile.Close(); err != nil {
 			return err
 		}
 	}

--- a/internal/testers/segmenter.go
+++ b/internal/testers/segmenter.go
@@ -215,6 +215,7 @@ func segmentingLoop(ctx context.Context, fileName string, inFileReal av.DemuxClo
 			if err != nil {
 				return err
 			}
+			defer inf.Close()
 			inFile.Demuxer = inf
 			// rs.counter.currentSegments = 0
 			inFile.Streams()

--- a/internal/testers/segmenter.go
+++ b/internal/testers/segmenter.go
@@ -129,14 +129,13 @@ func segmentingLoop(ctx context.Context, fileName string, inFileReal av.DemuxClo
 		return err
 	}
 	for i, st := range streams {
-		codec := st.Type()
-		ctype := "unknown"
-		if codec.IsAudio() {
-			ctype = "audio"
+		codecType := "unknown"
+		if codec := st.Type(); codec.IsAudio() {
+			codecType = "audio"
 		} else if codec.IsVideo() {
-			ctype = "video"
+			codecType = "video"
 		}
-		streamTypes[int8(i)] = ctype
+		streamTypes[int8(i)] = codecType
 	}
 	glog.V(model.VERBOSE).Infof("Stream types=%+v", streamTypes)
 

--- a/internal/testers/segmenter.go
+++ b/internal/testers/segmenter.go
@@ -35,8 +35,7 @@ func StartSegmentingR(ctx context.Context, reader io.ReadSeekCloser, stopAtFileE
 		return err
 	}
 	go segmentingLoop(ctx, "", inFile, stopAtFileEnd, stopAfter, skipFirst, segLen, useWallTime, out)
-
-	return err
+	return nil
 }
 
 func StartSegmenting(ctx context.Context, fileName string, stopAtFileEnd bool, stopAfter, skipFirst, segLen time.Duration,
@@ -44,11 +43,11 @@ func StartSegmenting(ctx context.Context, fileName string, stopAtFileEnd bool, s
 	glog.Infof("Starting segmenting file %s", fileName)
 	inFile, err := avutil.Open(fileName)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Errorf("avutil.OpenRC err=%v", err)
+		return err
 	}
 	go segmentingLoop(ctx, fileName, inFile, stopAtFileEnd, stopAfter, skipFirst, segLen, useWallTime, out)
-
-	return err
+	return nil
 }
 
 func createInMemoryTSMuxer() (av.Muxer, *bytes.Buffer) {


### PR DESCRIPTION
This is to fix the error handling in the testers/segmenter which is used by all 
file-segmenting logic in livepeer.com outside of mist.

This includes `task-runner`, which is currently crashing anytime a segmenting 
error happens on any task. Fixing that is the main objective of fixing this bug.

This fixes https://github.com/livepeer/task-runner/issues/37