### PR TITLE
record-tester: Isolate stream health alerts from all others

### DIFF
--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -185,7 +185,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		}
 		if srerr != nil {
 			glog.Warningf("Streaming returned error err=%v", srerr)
-			return 3, err
+			return 3, srerr
 		}
 		stats, err := sr2.Stats()
 		if err != nil {
@@ -210,7 +210,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 			}
 			if srerr != nil {
 				glog.Warningf("Streaming second returned error err=%v", srerr)
-				return 3, err
+				return 3, srerr
 			}
 			stats, err := sr2.Stats()
 			if err != nil {

--- a/internal/app/vodtester/continuous_vod_tester.go
+++ b/internal/app/vodtester/continuous_vod_tester.go
@@ -124,7 +124,7 @@ func (cvt *continuousVodTester) sendPagerdutyEvent(vt IVodTester, err error) {
 		Source:    cvt.host,
 		Component: cvt.pagerDutyComponent,
 		Severity:  severity,
-		Summary:   fmt.Sprintf("%s:movie_camera: VOD %s for `%s` error: %v", lopriPrefix, cvt.pagerDutyComponent, cvt.host, err),
+		Summary:   fmt.Sprintf("%s:vhs: VOD %s for `%s` error: %v", lopriPrefix, cvt.pagerDutyComponent, cvt.host, err),
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}
 	resp, err := pagerduty.ManageEvent(event)

--- a/internal/app/vodtester/vodtester_app.go
+++ b/internal/app/vodtester/vodtester_app.go
@@ -55,6 +55,7 @@ func (vt *vodTester) Start(fileUrl string, taskPollDuration time.Duration) (int,
 		glog.Errorf("Error importing asset err=%v", err)
 		return 242, fmt.Errorf("error importing asset: %w", err)
 	}
+	defer vt.lapi.DeleteAsset(importAsset.ID)
 	glog.Infof("Importing asset taskId=%s outputAssetId=%s", importTask.ID, importAsset.ID)
 
 	startTime = time.Now()
@@ -85,6 +86,7 @@ func (vt *vodTester) Start(fileUrl string, taskPollDuration time.Duration) (int,
 		glog.Errorf("Error transcoding asset id=%s, err=%v", importAsset.ID, err)
 		return 242, fmt.Errorf("error transcoding asset id=%s: %w", importAsset.ID, err)
 	}
+	defer vt.lapi.DeleteAsset(transcodeAsset.ID)
 	glog.Infof("Asset imported id=%s, transcoding taskId=%s outputAssetId=%s", importAsset.ID, transcodeTask.ID, transcodeAsset.ID)
 
 	startTime = time.Now()

--- a/internal/app/vodtester/vodtester_app.go
+++ b/internal/app/vodtester/vodtester_app.go
@@ -55,7 +55,6 @@ func (vt *vodTester) Start(fileUrl string, taskPollDuration time.Duration) (int,
 		glog.Errorf("Error importing asset err=%v", err)
 		return 242, fmt.Errorf("error importing asset: %w", err)
 	}
-	defer vt.lapi.DeleteAsset(importAsset.ID)
 	glog.Infof("Importing asset taskId=%s outputAssetId=%s", importTask.ID, importAsset.ID)
 
 	startTime = time.Now()
@@ -86,7 +85,6 @@ func (vt *vodTester) Start(fileUrl string, taskPollDuration time.Duration) (int,
 		glog.Errorf("Error transcoding asset id=%s, err=%v", importAsset.ID, err)
 		return 242, fmt.Errorf("error transcoding asset id=%s: %w", importAsset.ID, err)
 	}
-	defer vt.lapi.DeleteAsset(transcodeAsset.ID)
 	glog.Infof("Asset imported id=%s, transcoding taskId=%s outputAssetId=%s", importAsset.ID, transcodeTask.ID, transcodeAsset.ID)
 
 	startTime = time.Now()

--- a/internal/testers/stream_health.go
+++ b/internal/testers/stream_health.go
@@ -3,7 +3,6 @@ package testers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,6 +20,10 @@ type (
 	// AnalyzerByRegion is a map of regions (generally just the base URL) to an
 	// analyzer client configured to connect there.
 	AnalyzerByRegion map[string]client.Analyzer
+
+	StreamHealthError struct {
+		Message string
+	}
 
 	streamHealth struct {
 		finite
@@ -88,7 +91,7 @@ func (h *streamHealth) workerLoop(waitForTarget time.Duration) {
 
 			msg := fmt.Sprintf("Global Stream Health API: stream did not become healthy on global analyzers after `%s`: %s",
 				waitForTarget, strings.Join(aggErrs, "; "))
-			h.fatalEnd(errors.New(msg))
+			h.fatalEnd(StreamHealthError{msg})
 			return
 		}
 	}
@@ -146,4 +149,8 @@ func conditionsStatus(health *data.HealthStatus) []string {
 		}
 	}
 	return failed
+}
+
+func (e StreamHealthError) Error() string {
+	return e.Message
 }


### PR DESCRIPTION
It is the most verbose of the tests and it is not 100% critical, so we shouldn't be paging
the on-call engineer with high urgency when they fire.

By keeping them together with all the other alerts, it also makes the other alerts less trusted
due to alert fatigue, and we end up ignoring real incidents.

On a higher level, we have moved away from the idea of the current Stream Health architecture
being the one and only source of truth for the Livepeer universe. So it is OK to start moving this
more to the background for now.