### PR TITLE
mapic: don't overwrite existing stream definitions

### DIFF
--- a/apis/mist/mist.go
+++ b/apis/mist/mist.go
@@ -292,7 +292,18 @@ func (mapi *API) caclChallengeResponse(password, challenge string) string {
 
 // CreateStream creates new stream in Mist server
 // func (mapi *API) CreateStream(name string, presets []string, profiles []Profile, segmentSize, customURL, source string) error
-func (mapi *API) CreateStream(name string, presets []string, profiles []Profile, segmentSize, customURL, source, hardcodedBroadcasters string, skipTranscoding, sendAudio bool) error {
+func (mapi *API) CreateStream(name string, presets []string, profiles []Profile, segmentSize, customURL, source, hardcodedBroadcasters string, skipTranscoding, sendAudio, overwrite bool) error {
+	if !overwrite {
+		streams, _, err := mapi.Streams()
+		if err != nil {
+			return err
+		}
+		_, exists := streams[name]
+		if exists {
+			glog.Infof("Mist stream '%s' already exists, skipping creation", name)
+			return nil
+		}
+	}
 	glog.Infof("Creating Mist stream '%s' with presets '%+v' profiles %+v", name, presets, profiles)
 	reqs := &addStreamReq{
 		Minimal:   1,

--- a/cmd/mapi/mapi.go
+++ b/cmd/mapi/mapi.go
@@ -187,7 +187,7 @@ func createStream(host, creds, token, name string) error {
 
 	mapi := mist.NewMist(host, credsp[0], credsp[1], token, mistPort)
 	mapi.Login()
-	mapi.CreateStream(name, []string{"P240p30fps16x9"}, nil, "", "", "", "", false, false)
+	mapi.CreateStream(name, []string{"P240p30fps16x9"}, nil, "", "", "", "", false, false, true)
 
 	return nil
 }

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -1018,7 +1018,7 @@ func (mc *mac) createMistStream(streamName string, stream *livepeer.CreateStream
 	}
 	audio := mc.shouldEnableAudio(stream)
 	err := mc.mapi.CreateStream(streamName, stream.Presets,
-		LivepeerProfiles2MistProfiles(stream.Profiles), "1", mc.lapi.GetServer()+"/api/stream/"+stream.ID, source, mc.mistHardcodedBroadcasters, skipTranscoding, audio)
+		LivepeerProfiles2MistProfiles(stream.Profiles), "1", mc.lapi.GetServer()+"/api/stream/"+stream.ID, source, mc.mistHardcodedBroadcasters, skipTranscoding, audio, true)
 	// err = mc.mapi.CreateStream(streamKey, stream.Presets, LivepeerProfiles2MistProfiles(stream.Profiles), "1", "http://host.docker.internal:3004/api/stream/"+stream.ID)
 	return err
 }
@@ -1126,13 +1126,13 @@ func (mc *mac) SetupTriggers(ownURI string) error {
 		apiURL := mc.lapi.GetServer() + "/api/stream/" + mc.baseStreamName
 		presets := []string{"P144p30fps16x9"}
 		// base stream created with audio disabled
-		err = mc.mapi.CreateStream(mc.baseStreamName, presets, nil, "1", apiURL, mc.mistStreamSource, mc.mistHardcodedBroadcasters, false, false)
+		err = mc.mapi.CreateStream(mc.baseStreamName, presets, nil, "1", apiURL, mc.mistStreamSource, mc.mistHardcodedBroadcasters, false, false, false)
 		if err != nil {
 			glog.Error(err)
 			return err
 		}
 		// create second stream with audio enabled - used for stream with recording enabled
-		err = mc.mapi.CreateStream(mc.baseStreamName+audioEnabledStreamSuffix, presets, nil, "1", apiURL, mc.mistStreamSource, mc.mistHardcodedBroadcasters, false, true)
+		err = mc.mapi.CreateStream(mc.baseStreamName+audioEnabledStreamSuffix, presets, nil, "1", apiURL, mc.mistStreamSource, mc.mistHardcodedBroadcasters, false, true, false)
 	}
 	return err
 }

--- a/internal/testers/streamer.go
+++ b/internal/testers/streamer.go
@@ -218,7 +218,7 @@ func (sr *streamer) startStreams(baseManfistID, sourceFileName string, repeatNum
 			}
 			manifestID := fmt.Sprintf("%s_%d_%d", baseManfistID, repeatNum, i)
 			if sr.mapi != nil {
-				err := sr.mapi.CreateStream(manifestID, []string{"P720p30fps16x9"}, nil, "1", "", "", "", false, false)
+				err := sr.mapi.CreateStream(manifestID, []string{"P720p30fps16x9"}, nil, "1", "", "", "", false, false, true)
 				if err != nil {
 					messenger.SendFatalMessage(fmt.Sprintf("Error creating stream %s on Mist", manifestID))
 				}


### PR DESCRIPTION
So we can actually tweak things about those streams in production configuration without having to run through mapic configuration every dang time.