### PR TITLE
build.yaml: Add GCP upload job for built binaries

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,12 @@
 version: 2
 
 updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - name: linux
@@ -22,6 +23,7 @@ jobs:
         arch:
           - arm64
           - amd64
+
     name: Build binaries for ${{ matrix.platform.name }}-${{ matrix.arch }}
     runs-on: ${{ matrix.platform.os }}
     steps:
@@ -81,23 +83,23 @@ jobs:
           app-bundle-id: "org.livepeer.lapi"
 
       - name: Archive binaries for windows
-        if: matrix.platform == 'windows'
+        if: matrix.platform.name == 'windows'
         run: |
           cd build/
           for file in $(find . -type f -perm -a+x)
           do
             f_name="$(basename $file)"
-            zip -9q "../releases/livepeer-${f_name/.exe/}-${GOOS}-${GOARCH}.zip" "livepeer-${f_name}"
+            zip -9q "../releases/${f_name/.exe/}-${GOOS}-${GOARCH}.zip" "${f_name}"
           done
 
       - name: Archive binaries for linux/macos
-        if: matrix.platform != 'windows'
+        if: matrix.platform.name != 'windows'
         run: |
           cd build/
           for file in $(find . -type f -perm -a+x)
           do
             f_name="$(basename $file)"
-            tar -czf "../releases/livepeer-${f_name}-${GOOS}-${GOARCH}.tar.gz" "livepeer-${f_name}"
+            tar -czf "../releases/${f_name}-${GOOS}-${GOARCH}.tar.gz" "${f_name}"
           done
 
       - name: Upload artifacts for cutting release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
           path: releases/
 
   upload:
-    name: Upload artifacts to google bucket
+    name: Upload ${{ matrix.project }} to google bucket
     permissions:
       contents: "read"
       id-token: "write"
@@ -139,7 +139,7 @@ jobs:
         run: |
           mkdir -p releases/
           cd "${{ steps.download.outputs.download-path }}/"
-          mv "*${{ matrix.project }}*" ../releases/
+          mv livepeer-${{ matrix.project }}* ../releases/
 
       - name: Generate sha256 checksum and gpg signatures for release artifacts
         uses: livepeer/action-gh-checksum-and-gpg-sign@latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,25 +13,18 @@ jobs:
     strategy:
       matrix:
         platform:
-          - linux
-          - windows
+          - name: linux
+            os: ubuntu-20.04
+          - name: windows
+            os: ubuntu-20.04
+          - name: darwin
+            os: macos-11
         arch:
           - arm64
           - amd64
-    name: Build binaries for ${{ matrix.platform }} platform (${{ matrix.arch }})
-    runs-on: ubuntu-20.04
+    name: Build binaries for ${{ matrix.platform.name }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.platform.os }}
     steps:
-      - name: Export OS and platform env
-        run: |
-          echo "GOOS=${{ matrix.platform }}" >> $GITHUB_ENV
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-
-      - name: Set up go
-        id: go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-
       - name: Check out code
         uses: actions/checkout@v3
         with:
@@ -40,96 +33,27 @@ jobs:
           # for ref value discussion
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Restore cache
-        id: cache-go-mod
-        uses: actions/cache@v3
+      - name: Set up go
+        id: go
+        uses: actions/setup-go@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-go-
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Export OS and platform env
+        run: |
+          echo "GOOS=${{ matrix.platform.name }}" >> $GITHUB_ENV
+          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Download dependencies
-        if: steps.cache-go-mod.outputs.cache-hit != 'true'
+        if: steps.go.outputs.cache-hit != 'true'
         run: go mod download
 
-      - name: Build
+      - name: Build and rename binaries
         run: |
           mkdir -p build/ releases/
           make -j4 all GO_BUILD_DIR="build/"
-
-      - name: Archive binaries for windows
-        if: matrix.platform == 'windows'
-        run: |
-          cd build/
-          for file in $(find . -type f -perm -a+x)
-          do
-            f_name="$(basename $file)"
-            mv "${f_name}" "livepeer-${f_name}"
-            zip -9q "../releases/livepeer-${f_name/.exe/}-${GOOS}-${GOARCH}.zip" "livepeer-${f_name}"
-          done
-
-      - name: Archive binaries for linux
-        if: matrix.platform == 'linux'
-        run: |
-          cd build/
-          for file in $(find . -type f -perm -a+x)
-          do
-            f_name="$(basename $file)"
-            mv "${f_name}" "livepeer-${f_name}"
-            tar -czf "../releases/livepeer-${f_name}-${GOOS}-${GOARCH}.tar.gz" "livepeer-${f_name}"
-          done
-
-      - name: Upload artifacts for cutting release
-        uses: actions/upload-artifact@master
-        with:
-          name: release-artifacts
-          path: releases/
-
-  macos:
-    strategy:
-      matrix:
-        arch:
-          - arm64
-          - amd64
-    name: Build binaries for macOS platform
-    runs-on: macos-11
-    steps:
-      - name: Set up go
-        id: go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          # Check https://github.com/livepeer/go-livepeer/pull/1891
-          # for ref value discussion
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Restore cache
-        id: cache-go-mod
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-go-
-
-      - name: Download dependencies
-        if: steps.cache-go-mod.outputs.cache-hit != 'true'
-        run: go mod download
-
-      - name: Build
-        run: |
-          mkdir -p build/ releases/
-          GOARCH="${{ matrix.arch }}" make -j4 all GO_BUILD_DIR="build/"
           cd build/
           for file in $(find . -type f -perm -a+x)
           do
@@ -145,7 +69,7 @@ jobs:
           regex: '^(master|main|v[0-9]+\.\d+\.\d+)$'
 
       - name: Codesign and notarize binaries
-        if: ${{ steps.match-tag.outputs.match != '' }}
+        if: steps.match-tag.outputs.match != '' && matrix.platform.name == 'darwin'
         uses: livepeer/action-gh-codesign-apple@latest
         with:
           developer-certificate-id: ${{ secrets.CI_MACOS_CERTIFICATE_ID }}
@@ -156,15 +80,25 @@ jobs:
           binary-path: "build/"
           app-bundle-id: "org.livepeer.lapi"
 
-      - name: Archive signed binary
+      - name: Archive binaries for windows
+        if: matrix.platform == 'windows'
         run: |
           cd build/
           for file in $(find . -type f -perm -a+x)
           do
             f_name="$(basename $file)"
-            tar -czf "../releases/${f_name}-darwin-${{ matrix.arch }}.tar.gz" "${f_name}"
+            zip -9q "../releases/livepeer-${f_name/.exe/}-${GOOS}-${GOARCH}.zip" "livepeer-${f_name}"
           done
-          cd -
+
+      - name: Archive binaries for linux/macos
+        if: matrix.platform != 'windows'
+        run: |
+          cd build/
+          for file in $(find . -type f -perm -a+x)
+          do
+            f_name="$(basename $file)"
+            tar -czf "../releases/livepeer-${f_name}-${GOOS}-${GOARCH}.tar.gz" "livepeer-${f_name}"
+          done
 
       - name: Upload artifacts for cutting release
         uses: actions/upload-artifact@master
@@ -172,72 +106,72 @@ jobs:
           name: release-artifacts
           path: releases/
 
-  # Disabled windows build job, to reduce time consumed overall
-  # windows:
-  #   defaults:
-  #     run:
-  #       shell: msys2 {0}
-  #   strategy:
-  #     matrix:
-  #       arch:
-  #         - arm64
-  #         - amd64
-  #   name: Build binaries for windows platform
-  #   runs-on: windows-2022
-  #   steps:
-  #     - uses: msys2/setup-msys2@v2
-  #       with:
-  #         update: true
-  #         install: >-
-  #           mingw-w64-x86_64-binutils
-  #           mingw-w64-x86_64-gcc
-  #           mingw-w64-x86_64-go
-  #           git
-  #           make
-  #           autoconf
-  #           automake
-  #           patch
-  #           libtool
-  #           texinfo
-  #           gtk-doc
-  #           zip
+  upload:
+    name: Upload artifacts to google bucket
+    permissions:
+      contents: "read"
+      id-token: "write"
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - lapi
+          - loadtester
+          - mapi
+          - mist-api-connector
+          - recordtester
+          - streamtester
+          - testdriver
+    steps:
+      - name: Download artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: release-artifacts
+          path: archives/
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #         # Check https://github.com/livepeer/go-livepeer/pull/1891
-  #         # for ref value discussion
-  #         ref: ${{ github.event.pull_request.head.sha }}
+      - name: Cleanup archives
+        run: |
+          mkdir -p releases/
+          cd "${{ steps.download.outputs.download-path }}/"
+          mv "*${{ matrix.project }}*" ../releases/
 
-  #     - name: Restore cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cache/go-build
-  #           ~/go/pkg/mod
-  #         key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.arch }}-go-
+      - name: Generate sha256 checksum and gpg signatures for release artifacts
+        uses: livepeer/action-gh-checksum-and-gpg-sign@latest
+        with:
+          artifacts-dir: releases
+          release-name: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          gpg-key: ${{ secrets.CI_GPG_SIGNING_KEY }}
+          gpg-key-passphrase: ${{ secrets.CI_GPG_SIGNING_PASSPHRASE }}
 
-  #     - name: Download dependencies
-  #       run: go mod download
+      - name: Generate branch manifest
+        id: branch-manifest
+        uses: livepeer/branch-manifest-action@latest
+        with:
+          project-name: ${{ matrix.project }}
 
-  #     - name: Build
-  #       run: |
-  #         mkdir -p build/ releases/
-  #         GOARCH="${{ matrix.arch }}" make -j4 all GO_BUILD_DIR="build/"
-  #         cd build/
-  #         for file in $(find . -type f -perm -a+x)
-  #         do
-  #           f_name="$(basename $file)"
-  #           mv "${f_name}" "livepeer-${f_name}"
-  #           zip -q9 "../releases/livepeer-${f_name/.exe/}-windows-${{ matrix.arch }}.zip" "livepeer-${f_name}"
-  #         done
-  #         cd -
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.CI_GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.CI_GOOGLE_SERVICE_ACCOUNT }}
 
-  #     - name: Upload artifacts for cutting release
-  #       uses: actions/upload-artifact@master
-  #       with:
-  #         name: release-artifacts
-  #         path: releases/
+      - name: Upload release archives to Google Cloud
+        id: upload-archives
+        uses: google-github-actions/upload-cloud-storage@v0
+        with:
+          path: releases
+          destination: "build.livepeer.live/${{ matrix.project }}/${{ (github.ref_type == 'tag' && github.ref_name) || github.sha }}"
+          parent: false
+
+      - name: Upload branch manifest file
+        id: upload-manifest
+        uses: google-github-actions/upload-cloud-storage@v0
+        with:
+          path: ${{ steps.branch-manifest.outputs.manifest-file }}
+          destination: "build.livepeer.live/${{ matrix.project }}/"
+          parent: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
       - "v*"
 
 jobs:
-  linux:
+  build:
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
Built binaries, are uploaded to gcp bucket for each commit. Additionally, merge multiple build jobs into a single one.

Part of work wrt: https://github.com/livepeer/livepeer-infra/issues/917