### PR TITLE
vod: vodloadtester (DirectUploads, ResumableUploads, Import)

### DIFF
--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -95,7 +95,7 @@ func main() {
 	vFlag.Value.Set(fmt.Sprintf("%d", cliFlags.Verbosity))
 
 	hostName, _ := os.Hostname()
-	runnerInfo := fmt.Sprintf("Hostname %s OS %s IPs %v\n", hostName, runtime.GOOS, utils.GetIPs())
+	runnerInfo := fmt.Sprintf("Hostname %s OS %s", hostName, runtime.GOOS)
 	fmt.Printf("Compiler version: %s %s\n", runtime.Compiler, runtime.Version())
 	fmt.Print(runnerInfo)
 

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -399,7 +399,7 @@ func (vt *vodLoadTester) checkTaskProcessing(taskPollDuration time.Duration, pro
 		}
 
 		if time.Since(startTime) > timeout {
-			glog.Errorf("Timeout processing task, taskId=%s", task.ID)
+			glog.Errorf("Internal timeout processing task, taskId=%s", task.ID)
 			return fmt.Errorf("timeout processing task, taskId=%s", task.ID)
 		}
 	}

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -65,7 +65,7 @@ func main() {
 	flag.Set("logtostderr", "true")
 	vFlag := flag.Lookup("v")
 
-	fs := flag.NewFlagSet("loadtester", flag.ExitOnError)
+	fs := flag.NewFlagSet("vodloadtester", flag.ExitOnError)
 
 	fs.IntVar(&cliFlags.Verbosity, "v", 3, "Log verbosity.  {4|5|6}")
 	fs.BoolVar(&cliFlags.Version, "version", false, "Print out the version")

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	api "github.com/livepeer/go-api-client"
+	"github.com/livepeer/stream-tester/internal/utils"
+	"github.com/peterbourgon/ff/v2"
+)
+
+type cliArguments struct {
+	Verbosity    int
+	Simultaneous uint
+	Version      bool
+	TaskCheck    bool
+	APIServer    string
+	APIToken     string
+	Filename     string
+	VideoAmount  uint
+	OutputPath   string
+
+	TestDuration       time.Duration
+	StartDelayDuration time.Duration
+}
+
+type vodLoadTester struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	lapi   *api.Client
+}
+
+type uploadTest struct {
+	StartTime            time.Time `json:"start_time"`
+	EndTime              time.Time `json:"end_time"`
+	RunnerInfo           string    `json:"runnerInfo,omitempty"`
+	Kind                 string    `json:"kind,omitempty"`
+	AssetID              string    `json:"assetId,omitempty"`
+	TaskID               string    `json:"taskId,omitempty"`
+	RequestUploadSuccess uint      `json:"requestUploadSuccess,omitempty"`
+	UploadSuccess        uint      `json:"uploadSuccess,omitempty"`
+	TaskCheckSuccess     uint      `json:"taskCheckSuccess,omitempty"`
+	ErrorMessage         string    `json:"errorMessage,omitempty"`
+}
+
+func main() {
+	var cliFlags = &cliArguments{}
+
+	flag.Set("logtostderr", "true")
+	vFlag := flag.Lookup("v")
+
+	fs := flag.NewFlagSet("loadtester", flag.ExitOnError)
+
+	fs.IntVar(&cliFlags.Verbosity, "v", 3, "Log verbosity.  {4|5|6}")
+	fs.BoolVar(&cliFlags.Version, "version", false, "Print out the version")
+	fs.BoolVar(&cliFlags.TaskCheck, "task-check", false, "Check task processing")
+
+	fs.UintVar(&cliFlags.VideoAmount, "video-amt", 1, "How many video to upload")
+	fs.DurationVar(&cliFlags.StartDelayDuration, "delay-between-groups", 10*time.Second, "Delay between starting group of uploads")
+
+	fs.UintVar(&cliFlags.Simultaneous, "sim", 1, "Number of simulteneous videos to upload")
+	fs.StringVar(&cliFlags.Filename, "file", "bbb_sunflower_1080p_30fps_normal_2min.mp4", "File to upload")
+	fs.StringVar(&cliFlags.APIToken, "api-token", "", "Token of the Livepeer API to be used")
+	fs.StringVar(&cliFlags.APIServer, "api-server", "origin.livepeer.com", "Server of the Livepeer API to be used")
+	fs.StringVar(&cliFlags.OutputPath, "output-path", "/tmp/results.ndjson", "Path to output result .ndjson file")
+
+	_ = fs.String("config", "", "config file (optional)")
+
+	ff.Parse(fs, os.Args[1:],
+		ff.WithConfigFileFlag("config"),
+		ff.WithConfigFileParser(ff.PlainParser),
+		ff.WithEnvVarPrefix("VODLOADTESTER"),
+	)
+	flag.CommandLine.Parse(nil)
+	vFlag.Value.Set(fmt.Sprintf("%d", cliFlags.Verbosity))
+
+	hostName, _ := os.Hostname()
+	runnerInfo := fmt.Sprintf("Hostname %s OS %s IPs %v\n", hostName, runtime.GOOS, utils.GetIPs())
+	fmt.Printf("Compiler version: %s %s\n", runtime.Compiler, runtime.Version())
+	fmt.Print(runnerInfo)
+
+	if cliFlags.Version {
+		return
+	}
+
+	if cliFlags.Filename == "" {
+		glog.Fatal("missing --file parameter")
+	}
+	var err error
+	var fileName string
+
+	if fileName, err = utils.GetFile(cliFlags.Filename, strings.ReplaceAll(hostName, ".", "_")); err != nil {
+		if err == utils.ErrNotFound {
+			glog.Fatalf("file %s not found\n", cliFlags.Filename)
+		} else {
+			glog.Fatalf("error getting file %s: %v\n", cliFlags.Filename, err)
+		}
+	}
+	glog.Infof("uploading video file %q", fileName)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if cliFlags.APIToken == "" {
+		glog.Fatalf("No API token provided")
+	}
+
+	apiToken := cliFlags.APIToken
+	apiServer := cliFlags.APIServer
+	outputNdjson := cliFlags.OutputPath
+
+	lApiOpts := api.ClientOptions{
+		Server:      apiServer,
+		AccessToken: apiToken,
+		Timeout:     240 * time.Second,
+	}
+	lapi, _ := api.NewAPIClientGeolocated(lApiOpts)
+	vt := &vodLoadTester{
+		lapi:   lapi,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < int(cliFlags.VideoAmount); i += int(cliFlags.Simultaneous) {
+		for j := 0; j < int(cliFlags.Simultaneous); j++ {
+			fmt.Printf("Uploading video %d/%d\n", i+j+1, cliFlags.VideoAmount)
+			wg.Add(1)
+			go func() {
+				uploadTest := uploadTest{
+					StartTime:  time.Now(),
+					RunnerInfo: runnerInfo,
+					Kind:       "directUpload",
+				}
+				assetId, taskId, err := vt.uploadAsset(fileName)
+				if err != nil {
+					glog.Errorf("Error uploading asset: %v", err)
+					if assetId == "" {
+						uploadTest.RequestUploadSuccess = 0
+						uploadTest.ErrorMessage = err.Error()
+					} else {
+						uploadTest.AssetID = assetId
+						uploadTest.RequestUploadSuccess = 1
+						uploadTest.UploadSuccess = 0
+					}
+				} else {
+					uploadTest.AssetID = assetId
+					uploadTest.TaskID = taskId
+					uploadTest.RequestUploadSuccess = 1
+					uploadTest.UploadSuccess = 1
+					if cliFlags.TaskCheck {
+						err := vt.checkTaskProcessing(5*time.Second, api.TaskOnlyId{ID: uploadTest.TaskID})
+						if err != nil {
+							uploadTest.TaskCheckSuccess = 0
+							uploadTest.ErrorMessage = err.Error()
+						} else {
+							uploadTest.TaskCheckSuccess = 1
+						}
+					}
+
+					uploadTest.EndTime = time.Now()
+					jsonString, err := json.Marshal(uploadTest)
+					if err != nil {
+						glog.Errorf("Error converting runTests to json: %v", err)
+					}
+					f, err := os.OpenFile(outputNdjson, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+					if err != nil {
+						glog.Errorf("Error opening %s: %v", outputNdjson, err)
+					}
+					defer f.Close()
+					if _, err := f.WriteString(string(jsonString) + "\n"); err != nil {
+						glog.Errorf("Error writing to %s: %v", outputNdjson, err)
+					}
+
+				}
+				wg.Done()
+			}()
+		}
+		time.Sleep(cliFlags.StartDelayDuration)
+	}
+
+	wg.Wait()
+
+}
+
+func (vt *vodLoadTester) uploadAsset(fileName string) (string, string, error) {
+	rndAssetName := fmt.Sprintf("load_test_%s", randName())
+
+	res, err := vt.lapi.RequestUpload(rndAssetName)
+	if err != nil {
+		fmt.Printf("error requesting upload: %v\n", err)
+		return "", "", err
+	}
+	uploadUrl := res.Url
+	assetId := res.Asset.ID
+	taskId := res.Task.ID
+
+	file, err := os.Open(fileName)
+
+	if err != nil {
+		fmt.Printf("error opening file %s: %v\n", fileName, err)
+		return assetId, taskId, err
+	}
+
+	err = vt.lapi.UploadAsset(vt.ctx, uploadUrl, file)
+	if err != nil {
+		fmt.Printf("error uploading asset: %v\n", err)
+		return assetId, taskId, err
+	}
+
+	fmt.Printf("Video uploaded for asset id %s\n", assetId)
+
+	return assetId, taskId, err
+}
+
+func (vt *vodLoadTester) checkTaskProcessing(taskPollDuration time.Duration, processingTask api.TaskOnlyId) error {
+	startTime := time.Now()
+	timeout := 3 * time.Minute
+	for {
+		glog.Infof("Waiting %s for task id=%s to be processed, elapsed=%s", taskPollDuration, processingTask.ID, time.Since(startTime))
+		time.Sleep(taskPollDuration)
+
+		task, err := vt.lapi.GetTask(processingTask.ID)
+		if err != nil {
+			glog.Errorf("Error retrieving task id=%s err=%v", processingTask.ID, err)
+			return fmt.Errorf("error retrieving task id=%s: %w", processingTask.ID, err)
+		}
+		if task.Status.Phase == "completed" {
+			glog.Infof("Task success, taskId=%s", task.ID)
+			return nil
+		}
+		if task.Status.Phase != "pending" && task.Status.Phase != "running" && task.Status.Phase != "waiting" {
+			glog.Errorf("Error processing task, taskId=%s status=%s error=%v", task.ID, task.Status.Phase, task.Status.ErrorMessage)
+			return fmt.Errorf("error processing task, taskId=%s status=%s error=%v", task.ID, task.Status.Phase, task.Status.ErrorMessage)
+		}
+
+		if time.Since(startTime) > timeout {
+			glog.Errorf("Timeout processing task, taskId=%s", task.ID)
+			return fmt.Errorf("timeout processing task, taskId=%s", task.ID)
+		}
+	}
+}
+
+func randName() string {
+	x := make([]byte, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = byte(rand.Uint32())
+	}
+	return fmt.Sprintf("%x", x)
+}

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -27,12 +27,13 @@ type cliArguments struct {
 	ResumableUpload bool
 	Import          bool
 
-	TaskCheck   bool
-	APIServer   string
-	APIToken    string
-	Filename    string
-	VideoAmount uint
-	OutputPath  string
+	TaskCheck        bool
+	TaskCheckTimeout uint
+	APIServer        string
+	APIToken         string
+	Filename         string
+	VideoAmount      uint
+	OutputPath       string
 
 	TestDuration       time.Duration
 	StartDelayDuration time.Duration
@@ -70,6 +71,8 @@ func main() {
 	fs.IntVar(&cliFlags.Verbosity, "v", 3, "Log verbosity.  {4|5|6}")
 	fs.BoolVar(&cliFlags.Version, "version", false, "Print out the version")
 	fs.BoolVar(&cliFlags.TaskCheck, "task-check", false, "Check task processing")
+
+	fs.UintVar(&cliFlags.TaskCheckTimeout, "task-timeout", 500, "Task check timeout in seconds")
 
 	fs.BoolVar(&cliFlags.DirectUpload, "direct", false, "Launch direct upload test")
 	fs.BoolVar(&cliFlags.ResumableUpload, "resumable", false, "Launch tus upload test")
@@ -376,7 +379,7 @@ func (vt *vodLoadTester) uploadAsset(fileName string, uploadUrl string, resumabl
 
 func (vt *vodLoadTester) checkTaskProcessing(taskPollDuration time.Duration, processingTask api.TaskOnlyId) error {
 	startTime := time.Now()
-	timeout := 3 * time.Minute
+	timeout := time.Duration(vt.cliFlags.TaskCheckTimeout) * time.Second
 	for {
 		glog.Infof("Waiting %s for task id=%s to be processed, elapsed=%s", taskPollDuration, processingTask.ID, time.Since(startTime))
 		time.Sleep(taskPollDuration)

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -49,8 +49,8 @@ type vodLoadTester struct {
 }
 
 type uploadTest struct {
-	StartTime            time.Time `json:"start_time"`
-	EndTime              time.Time `json:"end_time"`
+	StartTime            time.Time `json:"startTime"`
+	EndTime              time.Time `json:"endTime"`
 	RunnerInfo           string    `json:"runnerInfo,omitempty"`
 	Kind                 string    `json:"kind,omitempty"`
 	AssetID              string    `json:"assetId,omitempty"`
@@ -92,7 +92,7 @@ func main() {
 	fs.UintVar(&cliFlags.Simultaneous, "sim", 1, "Number of simulteneous videos to upload")
 	fs.StringVar(&cliFlags.Filename, "file", "bbb_sunflower_1080p_30fps_normal_2min.mp4", "File to upload or url to import. Can be either a video or a .json array of objects with a url key")
 	fs.StringVar(&cliFlags.APIToken, "api-token", "", "Token of the Livepeer API to be used")
-	fs.StringVar(&cliFlags.APIServer, "api-server", "origin.livepeer.com", "Server of the Livepeer API to be used")
+	fs.StringVar(&cliFlags.APIServer, "api-server", "origin.livepeer.monster", "Server of the Livepeer API to be used")
 	fs.StringVar(&cliFlags.OutputPath, "output-path", "/tmp/results.ndjson", "Path to output result .ndjson file")
 
 	_ = fs.String("config", "", "config file (optional)")
@@ -492,7 +492,7 @@ func (vt *vodLoadTester) checkTaskProcessing(taskPollDuration time.Duration, pro
 		task, err := vt.lapi.GetTask(processingTask.ID)
 		if err != nil {
 			glog.Errorf("Error retrieving task id=%s err=%v", processingTask.ID, err)
-			if strings.Contains(err.Error(), "connection reset by peer") {
+			if strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "520") {
 				// Retry
 				continue
 			}

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/eventials/go-tus"
 	"github.com/golang/glog"
 	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/stream-tester/internal/utils"
@@ -309,7 +308,6 @@ func (vt *vodLoadTester) uploadAsset(fileName string, uploadUrl string) error {
 	return err
 }
 
-// Temporary function while waiting for go-api-client to get fixed
 func (vt *vodLoadTester) uploadAssetResumable(url string, fileName string) error {
 
 	file, err := os.Open(fileName)
@@ -319,31 +317,10 @@ func (vt *vodLoadTester) uploadAssetResumable(url string, fileName string) error
 		return err
 	}
 
-	defer file.Close()
-
-	config := tus.DefaultConfig()
-	config.ChunkSize = 5 * 1024 * 1024 // S3 complains if less than 5MB
-
-	client, err := tus.NewClient(url, config)
-	if err != nil {
-		fmt.Printf("error creating tus client: %v\n", err)
-		return err
-	}
-	upload, err := tus.NewUploadFromFile(file)
-	if err != nil {
-		fmt.Printf("error creating new upload from file: %v\n", err)
-		return err
-	}
-	uploader, err := client.CreateUpload(upload)
-	if err != nil {
-		fmt.Printf("error creating upload: %v\n", err)
-		return err
-	}
-
-	err = uploader.Upload()
+	err = vt.lapi.ResumableUpload(url, file)
 
 	if err != nil {
-		fmt.Printf("error resumable uploading asset: %v\n", err)
+		fmt.Printf("error on resumable upload asset: %v", err)
 	}
 
 	return err

--- a/cmd/vodloadtester/vodloadtester.go
+++ b/cmd/vodloadtester/vodloadtester.go
@@ -405,6 +405,7 @@ func (vt *vodLoadTester) writeResultNdjson(uploadTest uploadTest) {
 	if _, err := f.WriteString(string(jsonString) + "\n"); err != nil {
 		glog.V(logs.SHORT).Infof("Error writing to %s: %v", vt.cliFlags.OutputPath, err)
 	}
+	glog.V(logs.SHORT).Infof("test results updated with new entry in %s", vt.cliFlags.OutputPath)
 }
 
 func (vt *vodLoadTester) doUpload(fileName string, uploadUrl string, resumable bool) error {
@@ -452,6 +453,7 @@ func (vt *vodLoadTester) checkTaskProcessing(processingTask api.TaskOnlyId) erro
 			glog.Errorf("Error retrieving task id=%s err=%v", processingTask.ID, err)
 			if strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "520") {
 				// Retry
+				glog.V(logs.SHORT).Infof("Livepeer Studio API unreachable, retrying getting task information.... ")
 				continue
 			}
 			return fmt.Errorf("error retrieving task id=%s: %w", processingTask.ID, err)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.2.9-0.20220916171125-c13c05817515
+	github.com/livepeer/go-api-client v0.4.10-0.20231016190638-afea57499662
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.2.9-0.20220908143323-8ff49d9fddce
+	github.com/livepeer/go-api-client v0.2.9-0.20220913191130-1f2f838f95d6
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.2.9-0.20220913191130-1f2f838f95d6
+	github.com/livepeer/go-api-client v0.2.9-0.20220916171125-c13c05817515
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.2.9-0.20220913191130-1f2f838f95d6 h1:vv0P8DHGKXBi8uwXQvDe4w5vIgNqE0WkKbuEkpIRHOA=
-github.com/livepeer/go-api-client v0.2.9-0.20220913191130-1f2f838f95d6/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.2.9-0.20220916171125-c13c05817515 h1:3UvLoSvntPi0Z/yW6zskPmZZwA+lnm0pQVIvG/uBnrE=
+github.com/livepeer/go-api-client v0.2.9-0.20220916171125-c13c05817515/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.2.9-0.20220908143323-8ff49d9fddce h1:YbZcqp276/5Dp/ys680emXveyt2UTHAirkhg1LUF5MQ=
-github.com/livepeer/go-api-client v0.2.9-0.20220908143323-8ff49d9fddce/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.2.9-0.20220913191130-1f2f838f95d6 h1:vv0P8DHGKXBi8uwXQvDe4w5vIgNqE0WkKbuEkpIRHOA=
+github.com/livepeer/go-api-client v0.2.9-0.20220913191130-1f2f838f95d6/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/go.sum
+++ b/go.sum
@@ -710,8 +710,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.2.9-0.20220916171125-c13c05817515 h1:3UvLoSvntPi0Z/yW6zskPmZZwA+lnm0pQVIvG/uBnrE=
-github.com/livepeer/go-api-client v0.2.9-0.20220916171125-c13c05817515/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.10-0.20231016190638-afea57499662 h1:KJ/L/Tz/brn1zgKnLSVAL4g3h/hfyvd3FCqdG2gdnmw=
+github.com/livepeer/go-api-client v0.4.10-0.20231016190638-afea57499662/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/internal/app/vodtester/vodtester_app.go
+++ b/internal/app/vodtester/vodtester_app.go
@@ -164,7 +164,7 @@ func (vt *vodTester) directUploadTester(fileName string, taskPollDuration time.D
 		return fmt.Errorf("error opening file=%s: %w", fileName, err)
 	}
 
-	err = vt.lapi.UploadAsset(uploadEndpoint, file)
+	err = vt.lapi.UploadAsset(vt.ctx, uploadEndpoint, file)
 	if err != nil {
 		glog.Errorf("Error uploading file filePath=%s err=%v", fileName, err)
 		return fmt.Errorf("error uploading for assetId=%s taskId=%s: %w", uploadAsset.ID, uploadTask.ID, err)


### PR DESCRIPTION
- [X] Direct uploads load test
- [x] Resumable uploads load test
- [X] Import from url load test
- [X] Import from a .json file containing a list of remote files (ipfs, https)
- [X] Upload files from a folder
- [X] Save results with success / fail in steps, with error messages coming from the pipeline

Notion doc for usage:
https://www.notion.so/livepeer/How-to-run-a-VOD-load-test-using-vodloadtester-0b3db771393a46a384ce7e05b614150a#4fa99de44d34404fb134c515c48faf93
```
Usage of vodloadtester:
  -api-server string
    	Server of the Livepeer API to be used (default "origin.livepeer.monster")
  -api-token string
    	Token of the Livepeer API to be used
  -config string
    	config file (optional)
  -delay-between-groups duration
    	Delay between starting group of uploads (default 10s)
  -direct
    	Launch direct upload test
  -file string
    	File to upload or url to import. Can be either a video or a .json array of objects with a url key
  -folder string
    	Folder with files to upload. The tester will search in the folder for files with the following extensions: mp4
  -import
    	Launch import from url test
  -keep-assets
    	Keep assets after test
  -output-path string
    	Path to output result .ndjson file (default "/tmp/results.ndjson")
  -probe-data
    	Write object data in results when importing a JSON file
  -resumable
    	Launch tus upload test
  -sim uint
    	Number of simulteneous videos to upload or import (batch size) (default 1)
  -task-check
    	Check task processing
  -task-poll-time uint
    	Task check poll time in seconds (default 5)
  -task-timeout uint
    	Task check timeout in seconds (default 500)
  -v int
    	Log verbosity.  {4|5|6} (default 5)
  -version
    	Print out the version
  -video-amt uint
    	How many video to upload or import (default 1)
```

Example output:
```
{"start_time":"2022-09-16T20:30:29.171494319+02:00","end_time":"2022-09-16T20:30:50.362233778+02:00","runnerInfo":"Hostname gioele-XPS-15-9510 OS linux","kind":"resumable","assetId":"f5e5cbd3-8179-4a65-acb8-29707f96f780","taskId":"4268d966-3819-4ec2-81c6-4c6da5691e99","requestUploadSuccess":1,"uploadSuccess":1,"taskCheckSuccess":1}
{"start_time":"2022-09-16T20:30:29.171489196+02:00","end_time":"2022-09-16T20:30:50.393028209+02:00","runnerInfo":"Hostname gioele-XPS-15-9510 OS linux","kind":"resumable","assetId":"3a03fafc-a186-45c9-a6d6-c238c0f419a9","taskId":"a44ed917-40ec-4308-baef-353d7f1d6b07","requestUploadSuccess":1,"uploadSuccess":1,"taskCheckSuccess":1}
{"start_time":"2022-09-16T20:30:44.172579442+02:00","end_time":"2022-09-16T20:31:04.380322533+02:00","runnerInfo":"Hostname gioele-XPS-15-9510 OS linux","kind":"resumable","assetId":"76b2b2dc-9473-4512-80bf-a8359b3ecf6f","taskId":"5e5fd631-8e7f-4724-9590-e92fcd31d60e","requestUploadSuccess":1,"uploadSuccess":1,"taskCheckSuccess":1}
{"start_time":"2022-09-16T20:30:44.172512413+02:00","end_time":"2022-09-16T20:31:04.405383898+02:00","runnerInfo":"Hostname gioele-XPS-15-9510 OS linux","kind":"resumable","assetId":"b0c168c0-177a-49f6-87d3-09966d41e5d0","taskId":"a12b9672-3d7e-4bb1-a037-2c90d101d795","requestUploadSuccess":1,"uploadSuccess":1,"taskCheckSuccess":1}
{"start_time":"2022-09-16T20:30:59.175543883+02:00","end_time":"2022-09-16T20:31:14.582551084+02:00","runnerInfo":"Hostname gioele-XPS-15-9510 OS linux","kind":"resumable","assetId":"c5ea0148-8c2f-4760-a324-e432ba112bc0","taskId":"1571a2a9-17b5-4b6a-b95e-625f3e07dd68","requestUploadSuccess":1,"uploadSuccess":1,"taskCheckSuccess":1}
```