### PR TITLE
mapic: Invert flag to skip mist stats

### DIFF
--- a/cmd/mist-api-connector/mist-api-connector.go
+++ b/cmd/mist-api-connector/mist-api-connector.go
@@ -41,7 +41,7 @@ func main() {
 	mistConnectTimeout := fs.Duration("mist-connect-timeout", 5*time.Minute, "Max time to wait attempting to connect to Mist server")
 	mistStreamSource := fs.String("mist-stream-source", "push://", "Stream source we should use for created Mist stream")
 	mistHardcodedBroadcasters := fs.String("mist-hardcoded-broadcasters", "", "Hardcoded broadcasters for use by MistProcLivepeer")
-	noMistScrapeMetrics := fs.Bool("no-mist-scrape-metrics", true, "Scrape statistics from MistServer and publish to RabbitMQ")
+	noMistScrapeMetrics := fs.Bool("no-mist-scrape-metrics", false, "Scrape statistics from MistServer and publish to RabbitMQ")
 	sendAudio := fs.String("send-audio", "record", "when should we send audio?  {always|never|record}")
 	apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used by the Mist server")
 	apiServer := fs.String("api-server", livepeer.ACServer, "Livepeer API server to use")

--- a/cmd/mist-api-connector/mist-api-connector.go
+++ b/cmd/mist-api-connector/mist-api-connector.go
@@ -41,7 +41,7 @@ func main() {
 	mistConnectTimeout := fs.Duration("mist-connect-timeout", 5*time.Minute, "Max time to wait attempting to connect to Mist server")
 	mistStreamSource := fs.String("mist-stream-source", "push://", "Stream source we should use for created Mist stream")
 	mistHardcodedBroadcasters := fs.String("mist-hardcoded-broadcasters", "", "Hardcoded broadcasters for use by MistProcLivepeer")
-	mistScrapeMetrics := fs.Bool("mist-scrape-metrics", true, "Scrape statistics from MistServer and publish to RabbitMQ")
+	noMistScrapeMetrics := fs.Bool("no-mist-scrape-metrics", true, "Scrape statistics from MistServer and publish to RabbitMQ")
 	sendAudio := fs.String("send-audio", "record", "when should we send audio?  {always|never|record}")
 	apiToken := fs.String("api-token", "", "Token of the Livepeer API to be used by the Mist server")
 	apiServer := fs.String("api-server", livepeer.ACServer, "Livepeer API server to use")
@@ -123,7 +123,7 @@ func main() {
 		OwnRegion:                 *ownRegion,
 		MistStreamSource:          *mistStreamSource,
 		MistHardcodedBroadcasters: *mistHardcodedBroadcasters,
-		MistScrapeMetrics:         *mistScrapeMetrics,
+		NoMistScrapeMetrics:       *noMistScrapeMetrics,
 	}
 	mc, err := mistapiconnector.NewMac(opts)
 	if err != nil {

--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -124,7 +124,7 @@ type (
 		AMQPUrl, OwnRegion            string
 		MistStreamSource              string
 		MistHardcodedBroadcasters     string
-		MistScrapeMetrics             bool
+		NoMistScrapeMetrics           bool
 	}
 
 	trackList map[string]*trackListDesc
@@ -263,7 +263,7 @@ func NewMac(opts MacOptions) (IMac, error) {
 		mistHardcodedBroadcasters: opts.MistHardcodedBroadcasters,
 	}
 	go mc.recoverSessionLoop()
-	if producer != nil && opts.MistScrapeMetrics {
+	if producer != nil && !opts.NoMistScrapeMetrics {
 		startMetricsCollector(ctx, statsCollectionPeriod, opts.NodeID, opts.OwnRegion, opts.MistAPI, producer, ownExchangeName, mc)
 	}
 	return mc, nil


### PR DESCRIPTION
Mist cant handle a boolean flag set to false,
its default value must be false instead and
it can only be set to true lol