### PR TITLE
mapic: Fix shutdown nil pointer error

### DIFF
--- a/internal/app/mistapiconnector/mistapiconnector_app.go
+++ b/internal/app/mistapiconnector/mistapiconnector_app.go
@@ -1234,7 +1234,9 @@ func (mc *mac) shutdown() {
 
 	err := mc.srv.Shutdown(ctx)
 	glog.Infof("Done shutting down server with err=%v", err)
-	mc.etcdClient.Close()
+	if mc.useEtcd {
+		mc.etcdClient.Close()
+	}
 	deactivateGroup.Wait()
 
 	mc.cancel()


### PR DESCRIPTION
We were closing the etcd client without checking that it was actually used.