### PR TITLE
recordtester: Find closest serf members when booting up recordtester

### DIFF
--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -59,10 +59,26 @@ func findInSlice(slice []geolocateSerfNodes, key string) int {
 	return -1
 }
 
-func getDistance(x1, y1, x2, y2 float64) float64 {
-	dx := x1 - x2
-	dy := y1 - y2
-	return math.Sqrt((dx * dx) + (dy * dy))
+const (
+	earthRadius = 6371 // Earth's radius in kilometers
+)
+
+func getDistance(lat1, lon1, lat2, lon2 float64) float64 {
+	// convert to radians
+	lat1 = lat1 * math.Pi / 180
+	lon1 = lon1 * math.Pi / 180
+	lat2 = lat2 * math.Pi / 180
+	lon2 = lon2 * math.Pi / 180
+
+	// haversine formula
+	a := math.Sin(lat2-lat1)*math.Sin(lat2-lat1) +
+		math.Cos(lat1)*math.Cos(lat2)*
+		math.Sin(lon2-lon1)*math.Sin(lon2-lon1)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+
+	distance := earthRadius * c
+
+	return distance
 }
 
 func getSerfMembers(useSerf bool, serfRPCAddr string) ([]serfClient.Member, error) {

--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"os/signal"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -34,13 +37,36 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type geolocateSerfNodes struct {
+	Key       string
+	Latitude  float64
+	Longitude float64
+	Distance  float64
+	Nodes     []serfClient.Member
+}
+
 func init() {
 	format.RegisterAll()
 	rand.Seed(time.Now().UnixNano())
 }
 
-func getSerfMembers(serfRPCAddr string) ([]serfClient.Member, error) {
-	if serfRPCAddr == "" {
+func findInSlice(slice []geolocateSerfNodes, key string) int {
+	for i, v := range slice {
+		if v.Key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+func getDistance(x1, y1, x2, y2 float64) float64 {
+	dx := x1 - x2
+	dy := y1 - y2
+	return math.Sqrt((dx * dx) + (dy * dy))
+}
+
+func getSerfMembers(useSerf bool, serfRPCAddr string) ([]serfClient.Member, error) {
+	if !useSerf || serfRPCAddr == "" {
 		return nil, nil
 	}
 	rpcClient, err := serfClient.NewRPCClient(serfRPCAddr)
@@ -54,6 +80,52 @@ func getSerfMembers(serfRPCAddr string) ([]serfClient.Member, error) {
 		return nil, err
 	}
 	return members, nil
+}
+
+func getMemberLocation(member serfClient.Member) (string, string) {
+	return member.Tags["latitude"], member.Tags["longitude"]
+}
+
+func getClosestSerfNodes(serfMembers []serfClient.Member, lat, long float64) []serfClient.Member {
+	locationKey := func(x, y string) string {
+		return fmt.Sprintf("%s-%s", x, y)
+	}
+	if serfMembers == nil {
+		return nil
+	}
+	var nodeDistances []geolocateSerfNodes
+	for _, member := range serfMembers {
+		x2, y2 := getMemberLocation(member)
+		key := locationKey(x2, y2)
+		index := findInSlice(nodeDistances, key)
+		if index == -1 {
+			lat2, _ := strconv.ParseFloat(x2, 64)
+			long2, _ := strconv.ParseFloat(y2, 64)
+			distance := getDistance(lat, long, lat2, long2)
+			node := geolocateSerfNodes{
+				Key:       key,
+				Latitude:  lat2,
+				Longitude: long2,
+				Distance:  distance,
+				Nodes:     []serfClient.Member{member},
+			}
+			nodeDistances = append(nodeDistances, node)
+		} else {
+			node := nodeDistances[index]
+			node.Nodes = append(node.Nodes, member)
+			nodeDistances[index] = node
+		}
+	}
+	sort.Slice(nodeDistances, func(i, j int) bool {
+		return nodeDistances[i].Distance <= nodeDistances[j].Distance
+	})
+	var returnMembers []serfClient.Member
+	index := 0
+	for (len(returnMembers) < 5) && (index < len(nodeDistances)) {
+		returnMembers = append(returnMembers, nodeDistances[index].Nodes...)
+		index++
+	}
+	return returnMembers
 }
 
 func main() {
@@ -97,6 +169,8 @@ func main() {
 	useSerf := fs.Bool("use-serf", false, "Use serf playback URLs")
 	useRandomSerfMember := fs.Bool("random-serf-member", false, "Use a random member from serf member list")
 	serfPullCount := fs.Int("pull-count", 1, "Number of serf nodes to pull playback from (requires `--use-serf`)")
+	latitude := fs.Float64("latitude", 0, "latitude/geolocation of this record testing instance")
+	longitude := fs.Float64("longitude", 0, "longitude/geolocation of this record testing instance")
 
 	_ = fs.String("config", "", "config file (optional)")
 
@@ -177,13 +251,13 @@ func main() {
 		}
 	}
 
-	serfMembers, err := getSerfMembers(*serfRPCAddr)
+	serfMembers, err := getSerfMembers(*useSerf, *serfRPCAddr)
 	if err != nil {
 		glog.Fatalf("failed to process serf members: %v", err)
 	}
 	serfOptions := recordtester.SerfOptions{
 		UseSerf:          *useSerf,
-		SerfMembers:      serfMembers,
+		SerfMembers:      getClosestSerfNodes(serfMembers, *latitude, *longitude),
 		RandomSerfMember: *useRandomSerfMember,
 		SerfPullCount:    *serfPullCount,
 	}

--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -86,7 +86,7 @@ func getMemberLocation(member serfClient.Member) (string, string) {
 	return member.Tags["latitude"], member.Tags["longitude"]
 }
 
-func getClosestSerfNodes(serfMembers []serfClient.Member, lat, long float64) []serfClient.Member {
+func getClosestSerfNodes(serfMembers []serfClient.Member, selectNodeCount int, lat, long float64) []serfClient.Member {
 	locationKey := func(x, y string) string {
 		return fmt.Sprintf("%s-%s", x, y)
 	}
@@ -121,7 +121,7 @@ func getClosestSerfNodes(serfMembers []serfClient.Member, lat, long float64) []s
 	})
 	var returnMembers []serfClient.Member
 	index := 0
-	for (len(returnMembers) < 5) && (index < len(nodeDistances)) {
+	for (len(returnMembers) < selectNodeCount) && (index < len(nodeDistances)) {
 		returnMembers = append(returnMembers, nodeDistances[index].Nodes...)
 		index++
 	}
@@ -169,6 +169,7 @@ func main() {
 	useSerf := fs.Bool("use-serf", false, "Use serf playback URLs")
 	useRandomSerfMember := fs.Bool("random-serf-member", false, "Use a random member from serf member list")
 	serfPullCount := fs.Int("pull-count", 1, "Number of serf nodes to pull playback from (requires `--use-serf`)")
+	serfNodeCount := fs.Int("serf-node-count", 5, "Count of serf nodes when selecting nearest members")
 	latitude := fs.Float64("latitude", 0, "latitude/geolocation of this record testing instance")
 	longitude := fs.Float64("longitude", 0, "longitude/geolocation of this record testing instance")
 
@@ -257,7 +258,7 @@ func main() {
 	}
 	serfOptions := recordtester.SerfOptions{
 		UseSerf:          *useSerf,
-		SerfMembers:      getClosestSerfNodes(serfMembers, *latitude, *longitude),
+		SerfMembers:      getClosestSerfNodes(serfMembers, *serfNodeCount, *latitude, *longitude),
 		RandomSerfMember: *useRandomSerfMember,
 		SerfPullCount:    *serfPullCount,
 	}


### PR DESCRIPTION
 - Uses basic pythagorean method to compute distance from node
 - Finds at least closest 5 serf nodes (if any)

Fixes #236 