### PR TITLE
dockerfile: Fix glibc dependency issue when building images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build and publish docker images
+    name: Build and publish ${{ matrix.build.name }} docker images
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -79,7 +79,7 @@ jobs:
           platforms: linux/amd64
           push: true
           build-args: |
-            version=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+            version=${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}
           tags: ${{ steps.meta.outputs.tags }}
           file: 'docker/${{ matrix.build.file }}'
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ COPY	.	.
 ARG	version
 
 RUN	go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" -tags h264 cmd/streamtester/streamtester.go
+
 RUN	parallel -q go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/{}/{}.go ::: testdriver mist-api-connector loadtester stream-monitor recordtester
 
 FROM	alpine:3.15.4
@@ -28,11 +29,11 @@ WORKDIR	/root
 COPY --from=builder	/root/*.mp4	./
 COPY --from=builder	/root/official_test_source_2s_keys_24pfs_30s_hls	official_test_source_2s_keys_24pfs_30s_hls
 
-COPY --from=builder	/root/streamtester	/usr/local/bin/streamtester
-COPY --from=builder	/root/testdriver	/usr/local/bin/testdriver
-COPY --from=builder	/root/mist-api-connector	/usr/local/bin/mist-api-connector
-COPY --from=builder	/root/loadtester	/usr/local/bin/loadtester
-COPY --from=builder	/root/stream-monitor	/usr/local/bin/stream-monitor
-COPY --from=builder	/root/recordtester	/usr/local/bin/recordtester
+COPY --from=builder	/root/streamtester	\
+	/root/testdriver	\
+	/root/mist-api-connector	\
+	/root/loadtester	\
+	/root/stream-monitor	\
+	/root/recordtester	/usr/local/bin/
 
 RUN	for b in testdriver mist-api-connector loadtester stream-monitor recordtester; do ln -s /usr/local/bin/$b ./$b; done

--- a/docker/Dockerfile.orch-tester
+++ b/docker/Dockerfile.orch-tester
@@ -13,7 +13,9 @@ RUN	go mod download
 
 COPY	.	.
 
-RUN	go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" \
+ARG	version
+
+RUN	CGO_ENABLED=0 go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" \
 	-tags mainnet \
 	cmd/orch-tester/orch_tester.go cmd/orch-tester/broadcaster_metrics.go
 
@@ -30,7 +32,5 @@ WORKDIR /root
 
 COPY --from=builder	/root/official_test_source_2s_keys_24pfs_30s_hls	official_test_source_2s_keys_24pfs_30s_hls
 COPY --from=builder	/root/orch_tester	/usr/local/bin/orch_tester
-
-RUN	ln -s /usr/local/bin/orch_tester ./
 
 ENTRYPOINT ["/usr/local/bin/orch_tester"]

--- a/docker/Dockerfile.orch-tester
+++ b/docker/Dockerfile.orch-tester
@@ -15,11 +15,11 @@ COPY	.	.
 
 ARG	version
 
-RUN	CGO_ENABLED=0 go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" \
+RUN	go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" \
 	-tags mainnet \
 	cmd/orch-tester/orch_tester.go cmd/orch-tester/broadcaster_metrics.go
 
-FROM	debian:stretch-slim
+FROM	debian:bullseye-slim
 
 RUN	apt update && \
 	apt install -y ca-certificates && \

--- a/docker/Dockerfile.record-tester
+++ b/docker/Dockerfile.record-tester
@@ -6,16 +6,17 @@ ENV	GOARCH="${TARGETARCH}"
 WORKDIR	/root
 
 ENV	GOFLAGS "-mod=readonly"
-ARG	version
 
 COPY	go.mod go.sum	./
 
 RUN	go mod download
 
+ARG	version
+
 COPY	.	.
 
-RUN	go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/streamtester/streamtester.go
-RUN	go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/recordtester/recordtester.go
+RUN	CGO_ENABLED=0 go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/streamtester/streamtester.go \
+	&& CGO_ENABLED=0 go build -ldflags="-X 'github.com/livepeer/stream-tester/model.Version=$version' -X 'github.com/livepeer/stream-tester/model.IProduction=true'" cmd/recordtester/recordtester.go
 
 FROM --platform=$TARGETPLATFORM	debian:stretch-slim
 
@@ -25,7 +26,6 @@ RUN	apt update && \
 	apt install -yqq ca-certificates curl && \
 	apt clean
 
-COPY --from=builder	/root/streamtester	/usr/local/bin/streamtester
-COPY --from=builder	/root/recordtester	/usr/local/bin/recordtester
+COPY --from=builder	/root/streamtester	/root/recordtester	/usr/local/bin/
 
 RUN	for b in recordtester streamtester; do ln -s /usr/local/bin/$b ./$b; done


### PR DESCRIPTION
raised by rafal in [discord thread][1]; where `orch-tester` is unable to run due to glibc mismatch between builder (github runner) machine and host machine.

this is also partly responsible because we're using ubuntu18 runners when building `livepeerci/build` image (which `orch-tester` uses) but the final build step is using `ubuntu-latest`.

changing our final docker image base from debian `stretch` to `bullseye` resolved the `glibc` mismatch.

[1]: https://discord.com/channels/423160867534929930/1006190767510917202/1067020718040166430