### PR TITLE
vodtester: Add E2E tests for playback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.4.2
+	github.com/livepeer/go-api-client v0.4.2-0.20230124192858-4ae2f6d037f3
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.4.2 h1:jfYY6lIpB6XOXSqJOKOc6eQ1VGlYJNh5W+7HFV0v6VE=
-github.com/livepeer/go-api-client v0.4.2/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.2-0.20230124192858-4ae2f6d037f3 h1:qmX+PwBhzvDiybrePyvDmgUK4+n1Ny53UtR0xohNMfs=
+github.com/livepeer/go-api-client v0.4.2-0.20230124192858-4ae2f6d037f3/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/internal/app/vodtester/vodtester_app.go
+++ b/internal/app/vodtester/vodtester_app.go
@@ -140,8 +140,15 @@ func (vt *vodTester) uploadViaUrlTester(vodImportUrl string, taskPollDuration ti
 
 	if err != nil {
 		glog.Errorf("Error processing asset assetId=%s taskId=%s", importAsset.ID, importTask.ID)
+		return nil, fmt.Errorf("error waiting for asset processing: %w", err)
 	}
-	return importAsset, err
+
+	if err := vt.checkPlayback(importAsset.ID); err != nil {
+		glog.Errorf("Error checking playback assetId=%s err=%v", importAsset.ID, err)
+		return nil, fmt.Errorf("error checking playback: %w", err)
+	}
+
+	return importAsset, nil
 }
 
 func (vt *vodTester) directUploadTester(fileName string, taskPollDuration time.Duration) error {
@@ -179,8 +186,15 @@ func (vt *vodTester) directUploadTester(fileName string, taskPollDuration time.D
 	err = vt.CheckTaskProcessing(taskPollDuration, uploadTask)
 	if err != nil {
 		glog.Errorf("Error processing asset assetId=%s taskId=%s", uploadAsset.ID, uploadTask.ID)
+		return fmt.Errorf("error waiting for asset processing: %w", err)
 	}
-	return err
+
+	if err := vt.checkPlayback(uploadAsset.ID); err != nil {
+		glog.Errorf("Error checking playback assetId=%s err=%v", uploadAsset.ID, err)
+		return fmt.Errorf("error checking playback: %w", err)
+	}
+
+	return nil
 }
 
 func (vt *vodTester) resumableUploadTester(fileName string, taskPollDuration time.Duration) error {
@@ -220,9 +234,15 @@ func (vt *vodTester) resumableUploadTester(fileName string, taskPollDuration tim
 
 	if err != nil {
 		glog.Errorf("Error processing asset assetId=%s taskId=%s", uploadAsset.ID, uploadTask.ID)
+		return fmt.Errorf("error waiting for asset processing: %w", err)
 	}
 
-	return err
+	if err := vt.checkPlayback(uploadAsset.ID); err != nil {
+		glog.Errorf("Error checking playback assetId=%s err=%v", uploadAsset.ID, err)
+		return fmt.Errorf("error checking playback: %w", err)
+	}
+
+	return nil
 }
 
 func (vt *vodTester) checkPlayback(assetID string) error {


### PR DESCRIPTION
We have missed this for too long and it's about time we have it now.

Works by:
 - Starts from the asset ID
 - Grabs the finalized asset object which contains both a playback ID but also the duration of the video, as probed by the platform itself
   - I wanted to avoid having to probe locally on vodtester, which is why I used the info from the API.
 - Calls playback info API to grab the playback URL 
   - Super relevant to do this instead of just using playback URL from the asset object, since this is a critical flow on the SDK. It's more about ensuring we test all entry-points than doing what a regular application would do
 - Uses existing code to check the HLS playlist
   - This is what we have in task-runner in the old pipeline as well. Doesn't work for some files (e.g. no audio), but works consistently for these we're testing with.
 - profit

This depends on https://github.com/livepeer/go-api-client/pull/25