### PR TITLE
mapic: Fix stats collection deadlock

### DIFF
--- a/internal/app/mistapiconnector/stats_collector.go
+++ b/internal/app/mistapiconnector/stats_collector.go
@@ -77,6 +77,7 @@ func (c *metricsCollector) collectMetrics(ctx context.Context) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		streamID, metrics := streamID, metrics
 
 		info, err := c.getStreamInfo(streamID)
 		if err != nil {
@@ -91,7 +92,6 @@ func (c *metricsCollector) collectMetrics(ctx context.Context) error {
 			continue
 		}
 
-		metrics := metrics
 		eg.Go(recovered(func() {
 			info.mu.Lock()
 			timeSinceBumped := time.Since(info.lastSeenBumpedAt)


### PR DESCRIPTION
Realized that we can't really use SetLimit with
recursive Go calls, as we might get to a state
where all routines are blocked waiting for another
routine to finish.

Fixed it by removing that recursion and parallelizing
only the SetActive+Publish calls.