### PR TITLE
recordtester: Fix session checks for catalyst recording tests

### DIFF
--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -165,6 +165,8 @@ func main() {
 	vodImportUrl := fs.String("vod-import-url", "https://storage.googleapis.com/lp_testharness_assets/bbb_sunflower_1080p_30fps_normal_2min.mp4", "URL for VOD import")
 	continuousTest := fs.Duration("continuous-test", 0, "Do continuous testing")
 	useHttp := fs.Bool("http", false, "Do HTTP tests instead of RTMP")
+	forceRecordingUrl := fs.Bool("force-recording-url", false, "Whether to force the API to return a recording URL (skip the user session timeout)")
+	recordingWaitTime := fs.Duration("recording-wait-time", 6*time.Minute+20*time.Second, "How long to wait after the stream ends before checking for recording")
 	testMP4 := fs.Bool("mp4", false, "Download MP4 of recording")
 	testStreamHealth := fs.Bool("stream-health", false, "Check stream health during test")
 	testLive := fs.Bool("live", false, "Check Live workflow")
@@ -330,7 +332,8 @@ func main() {
 		Analyzers:           lanalyzers,
 		Ingest:              ingest,
 		RecordObjectStoreId: *recordObjectStoreId,
-		UseForceURL:         true,
+		UseForceURL:         *forceRecordingUrl,
+		RecordingWaitTime:   *recordingWaitTime,
 		UseHTTP:             *useHttp,
 		TestMP4:             *testMP4,
 		TestStreamHealth:    *testStreamHealth,

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -258,17 +258,20 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		return 252, err
 	}
 	glog.Infof("Sessions: %+v", sessions)
-	sessionsLength := len(sessions)
-	if sessionsLength == 2 {
-		// We often see failures for 2 sessions, this should be fixed once we move to catalyst recording but for now
-		// we want to ignore these to reduce the alert noise
-		return 0, nil
-	} else if sessionsLength != 1 {
-		err := fmt.Errorf("invalid session count, got %d", sessionsLength)
+
+	expectedSessions := 1
+	if pauseDuration > 0 {
+		expectedSessions = 2
+	}
+
+	if len(sessions) != expectedSessions {
+		err := fmt.Errorf("invalid session count, expected %d but got %d",
+			expectedSessions, len(sessions))
 		glog.Error(err)
 		// exit(251, fileName, *fileArg, err)
 		return 251, err
 	}
+
 	sess := sessions[0]
 	if len(sess.Profiles) != len(stream.Profiles) {
 		glog.Infof("session: %+v", sess)

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -169,6 +169,10 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		})
 	}
 
+	// when pauseDuration is set, we will stream the same file twice sleeping for
+	// the specified duration in between each.
+	streamTwice := pauseDuration > 0
+
 	mediaURL := fmt.Sprintf("%s/%s/index.m3u8", ingest.Playback, stream.PlaybackID)
 	if rt.serfOpts.UseSerf {
 		index := 0
@@ -186,7 +190,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 			glog.Warningf("Streaming returned error err=%v", sterr)
 			return 3, err
 		}
-		if pauseDuration > 0 {
+		if streamTwice {
 			glog.Infof("Pause specified, waiting %s before streaming second time", pauseDuration)
 			time.Sleep(pauseDuration)
 			sterr = rt.doOneHTTPStream(fileName, streamName, broadcasters[0], testDuration, stream)
@@ -219,7 +223,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		if err = rt.isCancelled(); err != nil {
 			return 0, err
 		}
-		if pauseDuration > 0 {
+		if streamTwice {
 			glog.Infof("Pause specified, waiting %s before streaming second time", pauseDuration)
 			time.Sleep(pauseDuration)
 			sr2 := testers.NewStreamer2(rt.ctx, testers.Streamer2Options{MistMode: true}, testerFuncs...)
@@ -261,7 +265,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	glog.Infof("Sessions: %+v", sessions)
 
 	expectedSessions := 1
-	if pauseDuration > 0 {
+	if streamTwice {
 		expectedSessions = 2
 	}
 

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -194,7 +194,6 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 				glog.Warningf("Second time streaming returned error err=%v", sterr)
 				return 3, err
 			}
-			testDuration *= 2
 		}
 	} else {
 
@@ -245,7 +244,6 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 			if err = rt.isCancelled(); err != nil {
 				return 0, err
 			}
-			testDuration *= 2
 		}
 	}
 	if err := rt.isCancelled(); err != nil {

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -312,51 +312,51 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		return 0, err
 	}
 
-	sess = sessions[0]
-	statusShould := api.RecordingStatusReady
-	if rt.useForceURL {
-		statusShould = api.RecordingStatusWaiting
-	}
-	if sess.RecordingStatus != statusShould {
-		err := fmt.Errorf("recording status is %s but should be %s", sess.RecordingStatus, statusShould)
-		return 240, err
-		// exit(250, fileName, *fileArg, err)
-	}
-	if sess.RecordingURL == "" {
-		err := fmt.Errorf("recording URL should appear by now")
-		return 249, err
-		// exit(249, fileName, *fileArg, err)
-	}
-	glog.Infof("recordingURL=%s downloading now", sess.RecordingURL)
+	for _, sess := range sessions {
+		sess = sessions[0]
+		statusShould := api.RecordingStatusReady
+		if rt.useForceURL {
+			statusShould = api.RecordingStatusWaiting
+		}
+		if sess.RecordingStatus != statusShould {
+			err := fmt.Errorf("recording status is %s but should be %s", sess.RecordingStatus, statusShould)
+			return 240, err
+			// exit(250, fileName, *fileArg, err)
+		}
+		if sess.RecordingURL == "" {
+			err := fmt.Errorf("recording URL should appear by now")
+			return 249, err
+			// exit(249, fileName, *fileArg, err)
+		}
+		glog.Infof("recordingURL=%s downloading now", sess.RecordingURL)
 
-	// started := time.Now()
-	// downloader := testers.NewM3utester2(gctx, sess.RecordingURL, false, false, false, false, 5*time.Second, nil)
-	// <-downloader.Done()
-	// glog.Infof(`Pulling stopped after %s`, time.Since(started))
-	// exit(55, fileName, *fileArg, err)
-	glog.Info("Done Record Test")
+		// started := time.Now()
+		// downloader := testers.NewM3utester2(gctx, sess.RecordingURL, false, false, false, false, 5*time.Second, nil)
+		// <-downloader.Done()
+		// glog.Infof(`Pulling stopped after %s`, time.Since(started))
+		// exit(55, fileName, *fileArg, err)
+		glog.Info("Done Record Test")
 
-	// lapi.DeleteStream(stream.ID)
-	// exit(0, fileName, *fileArg, err)
-	if err = rt.isCancelled(); err != nil {
-		return 0, err
-	}
-	if rt.mp4 {
-		es, err := rt.checkDownMp4(stream, sess.Mp4Url, testDuration, pauseDuration > 0)
+		// lapi.DeleteStream(stream.ID)
+		// exit(0, fileName, *fileArg, err)
+		if err = rt.isCancelled(); err != nil {
+			return 0, err
+		}
+		if rt.mp4 {
+			es, err := rt.checkDownMp4(stream, sess.Mp4Url, testDuration, pauseDuration > 0)
+			if err != nil {
+				return es, err
+			}
+		}
+
+		es, err := rt.checkDown(stream, sess.RecordingURL, testDuration, pauseDuration > 0)
 		if err != nil {
 			return es, err
 		}
 	}
 
-	es, err := rt.checkDown(stream, sess.RecordingURL, testDuration, pauseDuration > 0)
-	if es == 0 {
-		rt.lapi.DeleteStream(stream.ID)
-		// exit(0, fileName, *fileArg, err)
-	}
-
-	// uploader := testers.NewRtmpStreamer(gctx, rtmpURL)
-	// uploader.StartUpload(fileName, rtmpURL, -1, 30*time.Second)
-	return es, err
+	rt.lapi.DeleteStream(stream.ID)
+	return 0, nil
 }
 
 func (rt *recordTester) getIngestInfo() (*api.Ingest, error) {

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -50,6 +50,7 @@ type (
 		Ingest              *api.Ingest
 		RecordObjectStoreId string
 		UseForceURL         bool
+		RecordingWaitTime   time.Duration
 		UseHTTP             bool
 		TestMP4             bool
 		TestStreamHealth    bool
@@ -63,6 +64,7 @@ type (
 		ingest              *api.Ingest
 		recordObjectStoreId string
 		useForceURL         bool
+		recordingWaitTime   time.Duration
 		useHTTP             bool
 		mp4                 bool
 		streamHealth        bool
@@ -86,6 +88,7 @@ func NewRecordTester(gctx context.Context, opts RecordTesterOptions, serfOpts Se
 		cancel:              cancel,
 		recordObjectStoreId: opts.RecordObjectStoreId,
 		useForceURL:         opts.UseForceURL,
+		recordingWaitTime:   opts.RecordingWaitTime,
 		useHTTP:             opts.UseHTTP,
 		mp4:                 opts.TestMP4,
 		streamHealth:        opts.TestStreamHealth,
@@ -292,7 +295,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	if rt.useForceURL {
 		time.Sleep(5 * time.Second)
 	} else {
-		time.Sleep(6*time.Minute + 20*time.Second)
+		time.Sleep(rt.recordingWaitTime)
 	}
 	if err = rt.isCancelled(); err != nil {
 		return 0, err


### PR DESCRIPTION
Review [with "ignore whitespace changes"](https://github.com/livepeer/stream-tester/pull/293/files?w=1) so the diff is cleaner.

This fixes the record-tester behavior for catalyst recording tests:
 - It expects 2 session objects instead of only 1 as before
 - It allows configuring for how long it should wait for the recording to be available 
   - (might wanna add some polling if we need a too high limit here)
 - Default to **not** using `forceUrl` which is not supported anymore
 - Tests all 2 sessions streamed instead of only the last one