### PR TITLE
Add more verbose logging to help understand VOD failures

### DIFF
--- a/internal/testers/m3utester2.go
+++ b/internal/testers/m3utester2.go
@@ -981,7 +981,7 @@ func (ms *m3uMediaStream) manifestPullerLoop(wowzaMode bool) {
 			ms.savePlayList.SeqNo = pl.SeqNo
 			gotManifest = true
 		}
-		glog.V(model.VVERBOSE).Infof("Got media playlist %s with %d (really %d (%d)) segments of url %s:", ms.resolution, len(pl.Segments), countSegments(pl), pl.Len(), surl)
+		glog.Infof("Got media playlist %s with %d (really %d (%d)) segments of url %s: %s", ms.resolution, len(pl.Segments), countSegments(pl), pl.Len(), surl, pl.String())
 		glog.V(model.INSANE2).Info(string(b))
 		now := time.Now()
 		var lastTimeDownloadStarted time.Time

--- a/model/models.go
+++ b/model/models.go
@@ -148,7 +148,7 @@ func (vs *VODStats) IsOk(streamDuration time.Duration, doubled bool) (bool, stri
 			}
 			if diff > segDiffShould {
 				ok = false
-				ers := fmt.Sprintf("number of segments between %s and %s differ by %d", lres, res, diff)
+				ers := fmt.Sprintf("number of segments between %s and %s differ by %d. %s: %d segments. %s: %d segments.", lres, res, diff, lres, lsn, res, sn)
 				errs = append(errs, ers)
 				glog.Warningf(ers)
 			}
@@ -160,7 +160,7 @@ func (vs *VODStats) IsOk(streamDuration time.Duration, doubled bool) (bool, stri
 			}
 			if durDiff > durDiffShould {
 				ok = false
-				ers := fmt.Sprintf("duration of stream between %s and %s differ by %s", lres, res, durDiff)
+				ers := fmt.Sprintf("duration of stream between %s and %s differ by %s. Duration of %s: %s. Duration of %s: %s", lres, res, durDiff, lres, ldur, res, vs.SegmentsDur[res])
 				errs = append(errs, ers)
 				glog.Warningf(ers)
 			}


### PR DESCRIPTION
We don't have a lot to go on at the moment other than that the manifests differ. 

The main thing I want to add here is dumping out each manifest we download, since I'm guessing the manifest is missing / malformed in some way, rather than subtly different.