### PR TITLE
Swap 2min test file for 1min

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Automatically built binaries can be found on
 
 - [bbb_sunflower_1080p_30fps_normal_t02.mp4](https://test-harness-gcp.livepeer.fish/bbb_sunflower_1080p_30fps_normal_t02.mp4)
 
-- [bbb_sunflower_1080p_30fps_normal_2min.mp4](https://test-harness-gcp.livepeer.fish/bbb_sunflower_1080p_30fps_normal_2min.mp4)
+- [bbb_sunflower_1080p_30fps_normal_1min.mp4](https://test-harness-gcp.livepeer.fish/bbb_sunflower_1080p_30fps_normal_1min.mp4)
 
 ## Command line
 

--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -162,7 +162,7 @@ func main() {
 	ingestStr := fs.String("ingest", "", "Ingest server info in JSON format including ingest and playback URLs. Should follow Livepeer API schema")
 	analyzerServers := fs.String("analyzer-servers", "", "Comma-separated list of base URLs to connect for the Stream Health Analyzer API (defaults to --api-server)")
 	fileArg := fs.String("file", "bbb_sunflower_1080p_30fps_normal_t02.mp4", "File to stream")
-	vodImportUrl := fs.String("vod-import-url", "https://test-harness-gcp.livepeer.fish/bbb_sunflower_1080p_30fps_normal_2min.mp4", "URL for VOD import")
+	vodImportUrl := fs.String("vod-import-url", "https://test-harness-gcp.livepeer.fish/bbb_sunflower_1080p_30fps_normal_1min.mp4", "URL for VOD import")
 	continuousTest := fs.Duration("continuous-test", 0, "Do continuous testing")
 	useHttp := fs.Bool("http", false, "Do HTTP tests instead of RTMP")
 	forceRecordingUrl := fs.Bool("force-recording-url", false, "Whether to force the API to return a recording URL (skip the user session timeout)")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN	apk add --no-cache make gcc musl-dev linux-headers git \
 
 WORKDIR	/root
 
-RUN	parallel wget https://test-harness-gcp.livepeer.fish/{} ::: official_test_source_2s_keys_24pfs.mp4 official_test_source_2s_keys_24pfs_3min.mp4 bbb_sunflower_1080p_30fps_normal_t02.mp4 bbb_sunflower_1080p_30fps_normal_2min.mp4 official_test_source_2s_keys_24pfs_30s.mp4 && \
+RUN	parallel wget https://test-harness-gcp.livepeer.fish/{} ::: official_test_source_2s_keys_24pfs.mp4 official_test_source_2s_keys_24pfs_3min.mp4 bbb_sunflower_1080p_30fps_normal_t02.mp4 bbb_sunflower_1080p_30fps_normal_1min.mp4 official_test_source_2s_keys_24pfs_30s.mp4 && \
 	wget -qO- https://test-harness-gcp.livepeer.fish/official_test_source_2s_keys_24pfs_30s_hls.tar.gz | tar xvz -C .
 
 COPY	go.mod	go.sum	./


### PR DESCRIPTION
As in https://github.com/livepeer/livepeer-infra/pull/1474, we don't lose anything by doing 1min instead of 2min and should save costs.