### PR TITLE
Log all errors when we fail to fetch a manifest

### DIFF
--- a/m3u8/tester.go
+++ b/m3u8/tester.go
@@ -33,7 +33,7 @@ func CheckStats(ctx context.Context, url string, expectedDuration time.Duration,
 	<-downloader.Done()
 	stats := downloader.VODStats()
 	if ok, ers := stats.IsOk(expectedDuration, false); !ok {
-		return model.VODStats{}, fmt.Errorf("playlist not ok: %s", ers)
+		return model.VODStats{}, fmt.Errorf("playlist at %s not ok: %s", url, ers)
 	}
 	return stats, nil
 }


### PR DESCRIPTION
Currently we just see that we didn't fetch a manifest within the timeout period, but don't get any information about why