### PR TITLE
recordtester: implement polling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,5 +189,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect
 )
-
-exclude github.com/gosuri/uilive v0.0.4 // cause memory corruption

--- a/internal/testers/m3utester2.go
+++ b/internal/testers/m3utester2.go
@@ -964,7 +964,7 @@ func (ms *m3uMediaStream) manifestPullerLoop(wowzaMode bool) {
 			ms.savePlayList.SeqNo = pl.SeqNo
 			gotManifest = true
 		}
-		glog.Infof("Got media playlist %s with %d (really %d (%d)) segments of url %s: %s", ms.resolution, len(pl.Segments), countSegments(pl), pl.Len(), surl, pl.String())
+		glog.Infof("Got media playlist %s with %d (really %d (%d)) segments of url %s", ms.resolution, len(pl.Segments), countSegments(pl), pl.Len(), surl)
 		glog.V(model.INSANE2).Info(string(b))
 		now := time.Now()
 		var lastTimeDownloadStarted time.Time


### PR DESCRIPTION
Instead of waiting six minutes to try and check a recording, let's try every five seconds until six minutes is up! Failures still take six minutes but successes can return much faster now.