### PR TITLE
webrtc-load-tester: Migrate from Cloud Run to Compute Engine

### DIFF
--- a/.github/workflows/load-test.yaml
+++ b/.github/workflows/load-test.yaml
@@ -59,7 +59,7 @@ jobs:
     name: Run ${{ inputs.playback-protocol }} load test
     runs-on: ubuntu-latest
     container:
-      image: livepeer/webrtc-load-tester:vg-fix-goog-band-limit
+      image: livepeer/webrtc-load-tester:master
     steps:
       - name: calculate-dates-and-times
         id: timestamp
@@ -179,7 +179,6 @@ jobs:
           LT_WEBRTC_DURATION: ${{ inputs.duration }}
           LT_WEBRTC_API_SERVER: ${{ steps.env.outputs.api-server }}
           LT_WEBRTC_API_TOKEN: ${{ steps.env.outputs.api-token }}
-          LT_WEBRTC_CONTAINER_IMAGE: livepeer/webrtc-load-tester:vg-fix-goog-band-limit
           LT_WEBRTC_STREAMER_REGION: ${{ inputs.streamer-region }}
           LT_WEBRTC_STREAMER_BASE_URL: ${{ steps.env.outputs.streamer-base-url }}
           LT_WEBRTC_STREAMER_INPUT_FILE: ${{ inputs.streamer-input-file }}

--- a/.github/workflows/load-test.yaml
+++ b/.github/workflows/load-test.yaml
@@ -59,7 +59,7 @@ jobs:
     name: Run ${{ inputs.playback-protocol }} load test
     runs-on: ubuntu-latest
     container:
-      image: livepeer/webrtc-load-tester:master
+      image: livepeer/webrtc-load-tester:vg-fix-goog-band-limit
     steps:
       - name: calculate-dates-and-times
         id: timestamp
@@ -179,6 +179,7 @@ jobs:
           LT_WEBRTC_DURATION: ${{ inputs.duration }}
           LT_WEBRTC_API_SERVER: ${{ steps.env.outputs.api-server }}
           LT_WEBRTC_API_TOKEN: ${{ steps.env.outputs.api-token }}
+          LT_WEBRTC_CONTAINER_IMAGE: livepeer/webrtc-load-tester:vg-fix-goog-band-limit
           LT_WEBRTC_STREAMER_REGION: ${{ inputs.streamer-region }}
           LT_WEBRTC_STREAMER_BASE_URL: ${{ steps.env.outputs.streamer-base-url }}
           LT_WEBRTC_STREAMER_INPUT_FILE: ${{ inputs.streamer-input-file }}

--- a/.github/workflows/load-test.yaml
+++ b/.github/workflows/load-test.yaml
@@ -227,7 +227,7 @@ jobs:
           DISCORD_USERNAME: ${{ github.triggering_actor }}
           DISCORD_EMBEDS: >
             [{
-              "title": "${{ inputs.playback-protocol }} load test has failed!,
+              "title": "${{ inputs.playback-protocol }} load test has failed!",
               "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "color": 8388608,
               "author": {

--- a/.github/workflows/load-test.yaml
+++ b/.github/workflows/load-test.yaml
@@ -186,8 +186,7 @@ jobs:
           LT_WEBRTC_PLAYBACK_MANIFEST_URL: "${{ steps.env.outputs.playback-manifest-url }}"
           LT_WEBRTC_PLAYBACK_JWT_PRIVATE_KEY: ${{ steps.env.outputs.playback-jwt-private-key }}
           LT_WEBRTC_PLAYBACK_VIEWERS_PER_WORKER: 10
-          LT_WEBRTC_PLAYBACK_VIEWERS_PER_CPU: 2
-          LT_WEBRTC_PLAYBACK_MEMORY_PER_VIEWER_MIB: 400
+          LT_WEBRTC_PLAYBACK_MACHINE_TYPE: n2-highcpu-4
           LT_WEBRTC_PLAYBACK_REGION_VIEWERS_JSON: '${{ inputs.playback-region-viewers-json }}'
           LT_WEBRTC_PLAYBACK_BASE_SCREENSHOT_FOLDER_OS: ${{ secrets.LOAD_TEST_SCREENSHOT_FOLDER_OS }}
           LT_WEBRTC_GOOGLE_CREDENTIALS_JSON: '${{ secrets.LOAD_TEST_GOOGLE_CREDENTIALS_JSON }}'

--- a/cmd/webrtc-load-tester/gcloud/compute.go
+++ b/cmd/webrtc-load-tester/gcloud/compute.go
@@ -150,7 +150,7 @@ func CreateVMGroup(ctx context.Context, spec VMTemplateSpec, templateURL, region
 // DeleteVMGroup deletes a VM group and waits for the operation to complete. It
 // doesn't receive a ctx because it's meant to run as a cleanup on shutdown.
 func DeleteVMGroup(region, groupName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	glog.Infof("Deleting VM group: %s", groupName)

--- a/cmd/webrtc-load-tester/gcloud/compute.go
+++ b/cmd/webrtc-load-tester/gcloud/compute.go
@@ -70,7 +70,7 @@ func CreateVMTemplate(ctx context.Context, spec VMTemplateSpec) (url, name strin
 						{
 							Name:        "External NAT",
 							Type:        "ONE_TO_ONE_NAT",
-							NetworkTier: "STANDARD",
+							NetworkTier: "PREMIUM",
 						},
 					},
 				},

--- a/cmd/webrtc-load-tester/gcloud/compute.go
+++ b/cmd/webrtc-load-tester/gcloud/compute.go
@@ -81,6 +81,14 @@ func CreateVMTemplate(ctx context.Context, spec VMTemplateSpec) (url, name strin
 						Key:   "gce-container-declaration",
 						Value: googleapi.String(string(containerSpec)),
 					},
+					{
+						Key:   "google-monitoring-enabled",
+						Value: googleapi.String("true"),
+					},
+					{
+						Key:   "google-logging-enabled",
+						Value: googleapi.String("true"),
+					},
 				},
 			}},
 	}

--- a/cmd/webrtc-load-tester/gcloud/compute.go
+++ b/cmd/webrtc-load-tester/gcloud/compute.go
@@ -30,7 +30,7 @@ type VMTemplateSpec struct {
 }
 
 func CreateVMTemplate(ctx context.Context, spec VMTemplateSpec) (url, name string, err error) {
-	templateName := fmt.Sprintf("load-tester-%s-%s", spec.TestID[:8], spec.Role)
+	name = fmt.Sprintf("load-tester-%s-%s", spec.TestID[:8], spec.Role)
 
 	containerSpec, err := yaml.Marshal(konlet.ContainerSpec{
 		Spec: konlet.ContainerSpecStruct{
@@ -48,7 +48,7 @@ func CreateVMTemplate(ctx context.Context, spec VMTemplateSpec) (url, name strin
 	}
 
 	template := &compute.InstanceTemplate{
-		Name:        templateName,
+		Name:        name,
 		Description: "test-id=" + spec.TestID,
 		Properties: &compute.InstanceProperties{
 			MachineType: spec.MachineType,
@@ -95,7 +95,7 @@ func CreateVMTemplate(ctx context.Context, spec VMTemplateSpec) (url, name strin
 		return "", "", fmt.Errorf("error creating GCE instance template: %w", err)
 	}
 
-	template, err = computeClient.InstanceTemplates.Get(projectID, templateName).Context(ctx).Do()
+	template, err = computeClient.InstanceTemplates.Get(projectID, name).Context(ctx).Do()
 	if err != nil {
 		return "", "", fmt.Errorf("error getting GCE instance template: %w", err)
 	}

--- a/cmd/webrtc-load-tester/gcloud/compute.go
+++ b/cmd/webrtc-load-tester/gcloud/compute.go
@@ -1,0 +1,249 @@
+package gcloud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	konlet "github.com/GoogleCloudPlatform/konlet/gce-containers-startup/types"
+	"github.com/golang/glog"
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	computeClient *compute.Service
+
+	konletRestartPolicyNever = konlet.RestartPolicyNever // just so we can take an address easily
+)
+
+type VMTemplateSpec struct {
+	ContainerImage string
+	Role           string
+	Args           []string
+
+	TestID      string
+	MachineType string
+}
+
+func CreateVMTemplate(ctx context.Context, spec VMTemplateSpec) (url, name string, err error) {
+	templateName := fmt.Sprintf("load-tester-%s-%s", spec.TestID[:8], spec.Role)
+
+	containerSpec, err := yaml.Marshal(konlet.ContainerSpec{
+		Spec: konlet.ContainerSpecStruct{
+			Containers: []konlet.Container{{
+				Name:    "load-tester",
+				Image:   spec.ContainerImage,
+				Command: []string{"webrtc-load-tester"},
+				Args:    append([]string{spec.Role}, spec.Args...),
+			}},
+			RestartPolicy: &konletRestartPolicyNever,
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("error creating VM container spec: %w", err)
+	}
+
+	template := &compute.InstanceTemplate{
+		Name:        templateName,
+		Description: "test-id=" + spec.TestID,
+		Properties: &compute.InstanceProperties{
+			MachineType: spec.MachineType,
+			Disks: []*compute.AttachedDisk{
+				{
+					Type:       "PERSISTENT",
+					Boot:       true,
+					AutoDelete: true,
+					InitializeParams: &compute.AttachedDiskInitializeParams{
+						SourceImage: "projects/cos-cloud/global/images/family/cos-stable",
+						DiskSizeGb:  10,
+					},
+				},
+			},
+			NetworkInterfaces: []*compute.NetworkInterface{
+				{
+					Name: "global/networks/default",
+					AccessConfigs: []*compute.AccessConfig{
+						{
+							Name:        "External NAT",
+							Type:        "ONE_TO_ONE_NAT",
+							NetworkTier: "STANDARD",
+						},
+					},
+				},
+			},
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{
+					{
+						Key:   "gce-container-declaration",
+						Value: googleapi.String(string(containerSpec)),
+					},
+				},
+			}},
+	}
+
+	op, err := computeClient.InstanceTemplates.Insert(projectID, template).Context(ctx).Do()
+	if err != nil {
+		return "", "", fmt.Errorf("error creating GCE instance template: %w", err)
+	}
+
+	err = waitForOperation(ctx, op)
+	if err != nil {
+		return "", "", fmt.Errorf("error creating GCE instance template: %w", err)
+	}
+
+	template, err = computeClient.InstanceTemplates.Get(projectID, templateName).Context(ctx).Do()
+	if err != nil {
+		return "", "", fmt.Errorf("error getting GCE instance template: %w", err)
+	}
+
+	return template.SelfLink, name, nil
+}
+
+func DeleteVMTemplate(templateName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	op, err := computeClient.InstanceTemplates.Delete(projectID, templateName).Context(ctx).Do()
+	if err != nil {
+		glog.Errorf("error deleting GCE instance template: %v", err)
+		return
+	}
+
+	err = waitForOperation(ctx, op)
+	if err != nil {
+		glog.Errorf("error deleting GCE instance template: %v", err)
+		return
+	}
+}
+
+func CreateVMGroup(ctx context.Context, spec VMTemplateSpec, templateURL, region string, numInstances int64) (string, error) {
+	name := fmt.Sprintf("load-tester-%s-%s-%s", spec.TestID[:8], spec.Role, region)
+	instanceGroupManager := &compute.InstanceGroupManager{
+		Name:             name,
+		Description:      "test-id=" + spec.TestID,
+		BaseInstanceName: name,
+		InstanceTemplate: templateURL,
+		TargetSize:       numInstances,
+	}
+
+	op, err := computeClient.RegionInstanceGroupManagers.Insert(projectID, region, instanceGroupManager).Context(ctx).Do()
+	if err != nil {
+		return "", fmt.Errorf("error creating instance group: %w", err)
+	}
+
+	return name, waitForOperation(ctx, op)
+}
+
+// DeleteVMGroup deletes a VM group and waits for the operation to complete. It
+// doesn't receive a ctx because it's meant to run as a cleanup on shutdown.
+func DeleteVMGroup(region, groupName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	op, err := computeClient.RegionInstanceGroupManagers.Delete(projectID, region, groupName).Context(ctx).Do()
+	if err != nil {
+		glog.Errorf("error deleting VM group %s: %v", groupName, err)
+		return
+	}
+
+	if err = waitForOperation(ctx, op); err != nil {
+		glog.Errorf("error deleting VM group %s: %v", groupName, err)
+		return
+	}
+}
+
+type VMGroupInfo struct {
+	Region, Name string
+}
+
+func DeleteVMGroups(groups []VMGroupInfo) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(groups))
+
+	for _, group := range groups {
+		go func(group VMGroupInfo) {
+			defer wg.Done()
+			DeleteVMGroup(group.Region, group.Name)
+		}(group)
+	}
+}
+
+func CheckVMGroupStatus(ctx context.Context, region, groupName string) error {
+	instances, err := computeClient.RegionInstanceGroupManagers.ListManagedInstances(projectID, region, groupName).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("error getting VM group instances: %w", err)
+	}
+
+	status := map[string]int{}
+	running := true
+	for _, instance := range instances.ManagedInstances {
+		status[instance.InstanceStatus]++
+		running = running && instance.InstanceStatus == "RUNNING"
+	}
+
+	glog.Infof("VM group %s: running=%v status=%v",
+		simpleName(groupName), running, status)
+
+	return nil
+}
+
+func ListVMGroups(ctx context.Context, region, testID string) ([]string, error) {
+	groups, err := computeClient.RegionInstanceGroupManagers.List(projectID, region).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error listing VM groups: %w", err)
+	}
+
+	var groupNames []string
+	for _, group := range groups.Items {
+		if group.Description == "test-id="+testID {
+			groupNames = append(groupNames, group.Name)
+		}
+	}
+
+	return groupNames, nil
+}
+
+func ListVMTemplates(ctx context.Context, testID string) ([]string, error) {
+	templates, err := computeClient.InstanceTemplates.List(projectID).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error listing VM templates: %w", err)
+	}
+
+	var templateNames []string
+	for _, template := range templates.Items {
+		if template.Description == "test-id="+testID {
+			templateNames = append(templateNames, template.Name)
+		}
+	}
+
+	return templateNames, nil
+}
+
+func waitForOperation(ctx context.Context, op *compute.Operation) (err error) {
+	for {
+		var currentOp *compute.Operation
+		if op.Region == "" {
+			currentOp, err = computeClient.GlobalOperations.Get(projectID, op.Name).Context(ctx).Do()
+		} else {
+			// op.Region is a fully qualified URL, grab only the last path segment which is the region name
+			region := op.Region[strings.LastIndex(op.Region, "/")+1:]
+			currentOp, err = computeClient.RegionOperations.Get(projectID, region, op.Name).Context(ctx).Do()
+		}
+		if err != nil {
+			return fmt.Errorf("error getting operation status: %w", err)
+		}
+
+		if currentOp.Status == "DONE" {
+			if currentOp.Error != nil {
+				return fmt.Errorf("operation error: %v", currentOp.Error.Errors)
+			}
+			return nil
+		}
+
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/cmd/webrtc-load-tester/gcloud/jobs.go
+++ b/cmd/webrtc-load-tester/gcloud/jobs.go
@@ -10,6 +10,7 @@ import (
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/golang/glog"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -29,6 +30,11 @@ func InitClients(ctx context.Context, credentialsJSON, credsProjectID string) (e
 	}
 
 	executionsClient, err = run.NewExecutionsClient(ctx, credsOpt)
+	if err != nil {
+		return err
+	}
+
+	computeClient, err = compute.NewService(ctx, credsOpt)
 	if err != nil {
 		return err
 	}

--- a/cmd/webrtc-load-tester/roles/orchestrator.go
+++ b/cmd/webrtc-load-tester/roles/orchestrator.go
@@ -216,9 +216,6 @@ func recoverLoadTest(ctx context.Context, args loadTestArguments) error {
 	glog.Infof("Recovering test with ID %s", args.TestID)
 	wait(ctx, 5*time.Second)
 
-	var vmGroups []gcloud.VMGroupInfo
-	defer func() { gcloud.DeleteVMGroups(vmGroups) }()
-
 	templates, err := gcloud.ListVMTemplates(ctx, args.TestID)
 	if err != nil {
 		return fmt.Errorf("failed to list VM templates: %w", err)
@@ -226,6 +223,9 @@ func recoverLoadTest(ctx context.Context, args loadTestArguments) error {
 	for _, template := range templates {
 		defer gcloud.DeleteVMTemplate(template)
 	}
+
+	var vmGroups []gcloud.VMGroupInfo
+	defer func() { gcloud.DeleteVMGroups(vmGroups) }()
 
 	for region := range args.Playback.RegionViewersJSON {
 		regionGroups, err := gcloud.ListVMGroups(ctx, region, args.TestID)

--- a/cmd/webrtc-load-tester/roles/orchestrator.go
+++ b/cmd/webrtc-load-tester/roles/orchestrator.go
@@ -286,7 +286,7 @@ func waitTestFinished(ctx context.Context, streamID string, vmGroups []gcloud.VM
 
 func streamerVMSpec(args loadTestArguments, streamKey string) gcloud.VMTemplateSpec {
 	// Stream for a little longer since viewers join slowly
-	additionalStreamDelay := args.Playback.DelayBetweenRegions * time.Duration(1+len(args.Playback.RegionViewersJSON))
+	additionalStreamDelay := args.Playback.DelayBetweenRegions*time.Duration(len(args.Playback.RegionViewersJSON)) + 3*time.Minute
 	duration := args.TestDuration + additionalStreamDelay
 
 	return gcloud.VMTemplateSpec{

--- a/cmd/webrtc-load-tester/roles/player.go
+++ b/cmd/webrtc-load-tester/roles/player.go
@@ -126,11 +126,13 @@ func runSinglePlayerTest(ctx context.Context, args playerArguments, idx uint) er
 	if args.ScreenshotFolderOS == nil {
 		tasks = append(tasks, chromedp.Sleep(args.TestDuration))
 	} else {
-		osFolder := args.ScreenshotFolderOS.
-			JoinPath(getHostname(), fmt.Sprintf("player-%d", idx)).
-			String()
+		osFolder := args.ScreenshotFolderOS
+		if region := getRegion(); region != "" {
+			osFolder = osFolder.JoinPath(region)
+		}
+		osFolder = osFolder.JoinPath(getHostname(), fmt.Sprintf("player-%d", idx))
 
-		driver, err := drivers.ParseOSURL(osFolder, true)
+		driver, err := drivers.ParseOSURL(osFolder.String(), true)
 		if err != nil {
 			return err
 		}
@@ -211,6 +213,15 @@ func getHostname() string {
 
 	hostname, _ := os.Hostname()
 	return hostname
+}
+
+func getRegion() string {
+	if zone := os.Getenv("ZONE"); zone != "" {
+		return zone
+	} else if gceZone := os.Getenv("GCE_ZONE"); gceZone != "" {
+		return gceZone
+	}
+	return ""
 }
 
 func addQuery(urlStr, name, value string) string {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/glog v1.1.2
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.4.14-0.20231122152358-8756b0dfa4f4
+	github.com/livepeer/go-api-client v0.4.14-0.20231130155418-dd87e78bea93
 	github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0
@@ -97,7 +97,7 @@ require (
 	google.golang.org/genproto v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 )
@@ -110,6 +110,7 @@ require (
 
 require (
 	cloud.google.com/go/run v1.3.1
+	github.com/GoogleCloudPlatform/konlet v0.0.0-20221118094820-015a8324dd48
 	github.com/chromedp/chromedp v0.9.3
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/livepeer/catalyst-api v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/GoogleCloudPlatform/konlet v0.0.0-20221118094820-015a8324dd48 h1:3WllLHYiJb0o2iy6QKSSFjC+ejLGZ74+rQ5tHCEdqKM=
+github.com/GoogleCloudPlatform/konlet v0.0.0-20221118094820-015a8324dd48/go.mod h1:rc3M3P9GlhytgXmz3APA1TzcVeF18r0HqJ8Uu3Fhi3Y=
 github.com/Necroforger/dgrouter v0.0.0-20200517224846-e66453b957c1 h1:3OHJOlf0r1CVSA1E3Ts4uLWsCnucYndMRjNk4rFiQdE=
 github.com/Necroforger/dgrouter v0.0.0-20200517224846-e66453b957c1/go.mod h1:FdMxPfOp4ppZW2OJjLagSMri7g5k9luvTm7Y3aIxQSc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -553,8 +555,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/catalyst-api v0.1.1 h1:WP4rHH88b+lsxo33wPCjl0yvqVDNyxkleZH1sA0M5GE=
 github.com/livepeer/catalyst-api v0.1.1/go.mod h1:d6XPE9ehhCutWhCqqcmlYqQa+e9bf3Ke92x+gRZlzoQ=
-github.com/livepeer/go-api-client v0.4.14-0.20231122152358-8756b0dfa4f4 h1:epSCD9cs+5gZy1lI8Ibjz7nRpcjvRDwF9/J/7IQkYIU=
-github.com/livepeer/go-api-client v0.4.14-0.20231122152358-8756b0dfa4f4/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.14-0.20231130155418-dd87e78bea93 h1:vQYapLFJ9EyRWTjOsJr1ullF0wiazRme2fSJDZnFrIs=
+github.com/livepeer/go-api-client v0.4.14-0.20231130155418-dd87e78bea93/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719 h1:468kFmwQFaI00eNCLL8qA5XuIBMwqqVgKEXvqS7msa8=
 github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719/go.mod h1:d6qTStiNmXTQ/5YLB9fhzgDV9MdXg3KmqESQpur2Ak0=
 github.com/livepeer/go-tools v0.3.0 h1:xK0mJyPWWyvj9Oi9nfLglhCtk0KM8883WB7VO1oPF8g=


### PR DESCRIPTION
We found out UDP networking issues with Cloud Run
and need to go lower level. This pretty much does
that.