### PR TITLE
[VID-482] Continous record tester - decrese max fails from 5 to 3

### DIFF
--- a/internal/app/recordtester/continuous_record_tester.go
+++ b/internal/app/recordtester/continuous_record_tester.go
@@ -91,19 +91,21 @@ func (crt *continuousRecordTester) Start(fileName string, testDuration, pauseDur
 			messenger.SendFatalMessage(msg)
 		} else if err != nil || es != 0 {
 			var re *testers.RTMPError
-			if errors.As(err, &re) && try < 4 {
+			if errors.As(err, &re) && try < 2 {
 				msg := fmt.Sprintf(":rotating_light: Test of %s ended with RTMP err=%v errCode=%v try=%d, trying %s time",
 					crt.host, err, es, try, getNth(try+2))
 				messenger.SendMessage(msg)
 				try++
+				glog.Info("Waiting 10 seconds before next try...")
 				time.Sleep(10 * time.Second)
 				continue
 			}
-			if notRtmpTry < 3 {
+			if notRtmpTry < 2 {
 				msg := fmt.Sprintf(":rotating_light: Test of %s ended with some err=%v errCode=%v try=%d, trying %s time",
 					crt.host, err, es, notRtmpTry, getNth(notRtmpTry+2))
 				messenger.SendMessage(msg)
 				notRtmpTry++
+				glog.Info("Waiting 5 seconds before next try...")
 				time.Sleep(5 * time.Second)
 				continue
 			}
@@ -202,7 +204,7 @@ func (crt *continuousRecordTester) Done() <-chan struct{} {
 	return crt.ctx.Done()
 }
 
-var nth = []string{"0", "first", "second", "third", "forth", "fifth"}
+var nth = []string{"0", "first", "second", "third"}
 
 func getNth(i int) string {
 	if i > 0 && i < len(nth) {

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -111,6 +111,8 @@ func Init(ctx context.Context, WebhookURL, UserName, UsersToNotify, botToken, ch
 	if WebhookURL != "" {
 		msgCh = make(chan []byte, 64)
 		go sendLoop()
+	} else {
+		glog.Info("Discord webhook url is not provided")
 	}
 }
 


### PR DESCRIPTION
Reduce number of retries from 5 to 3 so we don't let repeating issues skip our monitoring.



I'd generally suggest to rewrite record-tester so it publishes prometheus metrics instead of PagerDuty alerts.
Alerts would be based on grafana metrics.
Retrials could produce a metric that would be observed… or record-tester would fail immediately and retry entire test. 
Then alerts could be configured to allow short, single failures of record-tester but repeating ones would raise an actual PagerDuty alert.
This is just a thought, it's not in the scope of this PR/task.