### PR TITLE
[ENG-1634] PagerDuty Summary field to be trimmed to 1024 chars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,7 +107,7 @@ jobs:
           done
 
       - name: Upload artifacts for cutting release
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3
         with:
           name: release-artifacts
           path: releases/

--- a/internal/app/recordtester/continuous_record_tester.go
+++ b/internal/app/recordtester/continuous_record_tester.go
@@ -164,11 +164,17 @@ func (crt *continuousRecordTester) sendPagerdutyEvent(rt IRecordTester, err erro
 		}
 		return
 	}
+
+	summary := fmt.Sprintf("%s%s %s for `%s` error: %v", lopriPrefix, componentName, crt.pagerDutyComponent, crt.host, err)
+	if len(summary) > 1024 {
+		summary = summary[:1024] // summary can be 1024 chars max
+	}
+
 	event.Payload = &pagerduty.V2Payload{
 		Source:    crt.host,
 		Component: crt.pagerDutyComponent,
 		Severity:  severity,
-		Summary:   fmt.Sprintf("%s%s %s for `%s` error: %v", lopriPrefix, componentName, crt.pagerDutyComponent, crt.host, err),
+		Summary:   summary,
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}
 	sid := rt.StreamID()


### PR DESCRIPTION
PagerDuty rejects some of our requests with `'summary' is too long (maiximum is 1024 characters)`
https://eu-metrics-monitoring.livepeer.live/grafana/goto/9aNMgnhSg?orgId=1

It caused recent cdn misconfiguration downtime unnoticed [[Discord](https://discord.com/channels/423160867534929930/1102968315137228900/1204794791708196955)]