### PR TITLE
record-tester: Add support for copy-only recordings

### DIFF
--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -176,6 +176,7 @@ func main() {
 	testTranscode := fs.Bool("transcode", false, "Check Transcode API workflow")
 	catalystPipelineStrategy := fs.String("catalyst-pipeline-strategy", "", "Which catalyst pipeline strategy to use regarding. The appropriate values are defined by catalyst-api itself.")
 	recordObjectStoreId := fs.String("record-object-store-id", "", "ID for the Object Store to use for recording storage. Forwarded to the streams created in the API")
+	recordingSpecStr := fs.String("recording-spec", "", "JSON object with the `recordingSpec` field to use in the test streams. Forwarded to the streams created in the API")
 
 	// Discord related flags
 	discordURL := fs.String("discord-url", "", "URL of Discord's webhook to send messages to Discord channel")
@@ -275,6 +276,13 @@ func main() {
 		}
 	}
 
+	var recordingSpec *api.RecordingSpec
+	if *recordingSpecStr != "" {
+		if err := json.Unmarshal([]byte(*recordingSpecStr), &recordingSpec); err != nil {
+			glog.Fatalf("Error parsing --recording-spec argument: %v", err)
+		}
+	}
+
 	serfMembers, err := getSerfMembers(*useSerf, *serfRPCAddr)
 	if err != nil {
 		glog.Fatalf("failed to process serf members: %v", err)
@@ -338,6 +346,7 @@ func main() {
 		Analyzers:           lanalyzers,
 		Ingest:              ingest,
 		RecordObjectStoreId: *recordObjectStoreId,
+		RecordingSpec:       recordingSpec,
 		UseForceURL:         *forceRecordingUrl,
 		RecordingWaitTime:   *recordingWaitTime,
 		UseHTTP:             *useHttp,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/glog v1.2.1
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.4.24-0.20240605154204-90c95287ac6a
+	github.com/livepeer/go-api-client v0.4.24-0.20240607131835-949d242a631b
 	github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/Necroforger/dgrouter v0.0.0-20200517224846-e66453b957c1
 	github.com/PagerDuty/go-pagerduty v1.7.0
 	github.com/bwmarrin/discordgo v0.27.1
-	github.com/golang/glog v1.1.2
+	github.com/golang/glog v1.2.1
 	github.com/gosuri/uilive v0.0.3 // indirect
 	github.com/gosuri/uiprogress v0.0.1
-	github.com/livepeer/go-api-client v0.4.14-0.20231130155418-dd87e78bea93
+	github.com/livepeer/go-api-client v0.4.24-0.20240605154204-90c95287ac6a
 	github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/leaderboard-serverless v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOW
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
-github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
-github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
+github.com/golang/glog v1.2.1 h1:OptwRhECazUx5ix5TTWC3EZhsZEHWcYWY4FQHTIubm4=
+github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -555,8 +555,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/catalyst-api v0.1.1 h1:WP4rHH88b+lsxo33wPCjl0yvqVDNyxkleZH1sA0M5GE=
 github.com/livepeer/catalyst-api v0.1.1/go.mod h1:d6XPE9ehhCutWhCqqcmlYqQa+e9bf3Ke92x+gRZlzoQ=
-github.com/livepeer/go-api-client v0.4.14-0.20231130155418-dd87e78bea93 h1:vQYapLFJ9EyRWTjOsJr1ullF0wiazRme2fSJDZnFrIs=
-github.com/livepeer/go-api-client v0.4.14-0.20231130155418-dd87e78bea93/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.24-0.20240605154204-90c95287ac6a h1:HDBUnOOx23w2tIn6fOYgep+TAlpW8JQkObbihhBnfXI=
+github.com/livepeer/go-api-client v0.4.24-0.20240605154204-90c95287ac6a/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719 h1:468kFmwQFaI00eNCLL8qA5XuIBMwqqVgKEXvqS7msa8=
 github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719/go.mod h1:d6qTStiNmXTQ/5YLB9fhzgDV9MdXg3KmqESQpur2Ak0=
 github.com/livepeer/go-tools v0.3.0 h1:xK0mJyPWWyvj9Oi9nfLglhCtk0KM8883WB7VO1oPF8g=

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/catalyst-api v0.1.1 h1:WP4rHH88b+lsxo33wPCjl0yvqVDNyxkleZH1sA0M5GE=
 github.com/livepeer/catalyst-api v0.1.1/go.mod h1:d6XPE9ehhCutWhCqqcmlYqQa+e9bf3Ke92x+gRZlzoQ=
-github.com/livepeer/go-api-client v0.4.24-0.20240605154204-90c95287ac6a h1:HDBUnOOx23w2tIn6fOYgep+TAlpW8JQkObbihhBnfXI=
-github.com/livepeer/go-api-client v0.4.24-0.20240605154204-90c95287ac6a/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.24-0.20240607131835-949d242a631b h1:J8cWLpnTINGAWVPU503SnUhTmuDhXnm9QxpC/CFGk2k=
+github.com/livepeer/go-api-client v0.4.24-0.20240607131835-949d242a631b/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719 h1:468kFmwQFaI00eNCLL8qA5XuIBMwqqVgKEXvqS7msa8=
 github.com/livepeer/go-livepeer v0.7.2-0.20231110152159-b17a70dfe719/go.mod h1:d6qTStiNmXTQ/5YLB9fhzgDV9MdXg3KmqESQpur2Ak0=
 github.com/livepeer/go-tools v0.3.0 h1:xK0mJyPWWyvj9Oi9nfLglhCtk0KM8883WB7VO1oPF8g=

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -51,6 +51,7 @@ type (
 		Analyzers           testers.AnalyzerByRegion
 		Ingest              *api.Ingest
 		RecordObjectStoreId string
+		RecordingSpec       *api.RecordingSpec
 		UseForceURL         bool
 		RecordingWaitTime   time.Duration
 		UseHTTP             bool
@@ -65,6 +66,7 @@ type (
 		lanalyzers          testers.AnalyzerByRegion
 		ingest              *api.Ingest
 		recordObjectStoreId string
+		recordingSpec       *api.RecordingSpec
 		useForceURL         bool
 		recordingWaitTime   time.Duration
 		useHTTP             bool
@@ -89,6 +91,7 @@ func NewRecordTester(gctx context.Context, opts RecordTesterOptions, serfOpts Se
 		ctx:                 ctx,
 		cancel:              cancel,
 		recordObjectStoreId: opts.RecordObjectStoreId,
+		recordingSpec:       opts.RecordingSpec,
 		useForceURL:         opts.UseForceURL,
 		recordingWaitTime:   opts.RecordingWaitTime,
 		useHTTP:             opts.UseHTTP,
@@ -132,7 +135,12 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format("2006-01-02T15:04:05Z07:00"))
 	var stream *api.Stream
 	for {
-		stream, err = rt.lapi.CreateStream(api.CreateStreamReq{Name: streamName, Record: true, RecordObjectStoreId: rt.recordObjectStoreId})
+		stream, err = rt.lapi.CreateStream(api.CreateStreamReq{
+			Name:                streamName,
+			Record:              true,
+			RecordingSpec:       rt.recordingSpec,
+			RecordObjectStoreId: rt.recordObjectStoreId,
+		})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++
@@ -418,7 +426,13 @@ func (rt *recordTester) doOneHTTPStream(fileName, streamName, broadcasterURL str
 	var err error
 	apiTry := 0
 	for {
-		session, err = rt.lapi.CreateStream(api.CreateStreamReq{Name: streamName, Record: true, RecordObjectStoreId: rt.recordObjectStoreId, ParentID: stream.ID})
+		session, err = rt.lapi.CreateStream(api.CreateStreamReq{
+			Name:                streamName,
+			Record:              true,
+			RecordingSpec:       rt.recordingSpec,
+			RecordObjectStoreId: rt.recordObjectStoreId,
+			ParentID:            stream.ID,
+		})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++


### PR DESCRIPTION
To use in E2E tests

Also fixed source playback checks when running with non-admin accounts (always).
