### PR TITLE
record-tester: Further improvements for Catalyst E2E tests

### DIFF
--- a/cmd/recordtester/recordtester.go
+++ b/cmd/recordtester/recordtester.go
@@ -177,6 +177,7 @@ func main() {
 	catalystPipelineStrategy := fs.String("catalyst-pipeline-strategy", "", "Which catalyst pipeline strategy to use regarding. The appropriate values are defined by catalyst-api itself.")
 	recordObjectStoreId := fs.String("record-object-store-id", "", "ID for the Object Store to use for recording storage. Forwarded to the streams created in the API")
 	recordingSpecStr := fs.String("recording-spec", "", "JSON object with the `recordingSpec` field to use in the test streams. Forwarded to the streams created in the API")
+	skipSourcePlayback := fs.Bool("skip-source-playback", false, "Whether to skip the source playback check on recordings processing validation")
 
 	// Discord related flags
 	discordURL := fs.String("discord-url", "", "URL of Discord's webhook to send messages to Discord channel")
@@ -347,6 +348,7 @@ func main() {
 		Ingest:              ingest,
 		RecordObjectStoreId: *recordObjectStoreId,
 		RecordingSpec:       recordingSpec,
+		SkipSourcePlayback:  *skipSourcePlayback,
 		UseForceURL:         *forceRecordingUrl,
 		RecordingWaitTime:   *recordingWaitTime,
 		UseHTTP:             *useHttp,

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -453,10 +453,14 @@ func (rt *recordTester) doOneHTTPStream(fileName, streamName, broadcasterURL str
 	var err error
 	apiTry := 0
 	for {
+		recordingSpec := rt.RecordingSpec
+		if recordingSpec == nil {
+			recordingSpec = &api.RecordingSpec{Profiles: &api.StandardProfiles}
+		}
 		session, err = rt.API.CreateStream(api.CreateStreamReq{
 			Name:                streamName,
 			Record:              true,
-			RecordingSpec:       rt.RecordingSpec,
+			RecordingSpec:       recordingSpec,
 			RecordObjectStoreId: rt.RecordObjectStoreId,
 			ParentID:            stream.ID,
 		})
@@ -559,6 +563,7 @@ func (rt *recordTester) checkRecordingHls(stream *api.Stream, url string, stream
 	if len(vs.SegmentsNum) != expectedProfiles {
 		glog.Warningf("Number of renditions doesn't match! Has %d should %d. streamId=%s playbackId=%s", len(vs.SegmentsNum), len(api.StandardProfiles)+1, stream.ID, stream.PlaybackID)
 		es = 35
+		return es, fmt.Errorf("number of renditions doesn't match (expected: %d actual: %d)", expectedProfiles, len(vs.SegmentsNum))
 	}
 	glog.V(model.DEBUG).Infof("Stats: %s streamId=%s playbackId=%s", vs.String(), stream.ID, stream.PlaybackID)
 	glog.V(model.DEBUG).Infof("Stats raw: %+v streamId=%s playbackId=%s", vs, stream.ID, stream.PlaybackID)

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -62,20 +62,11 @@ type (
 	}
 
 	recordTester struct {
-		ctx                 context.Context
-		cancel              context.CancelFunc
-		lapi                *api.Client
-		lanalyzers          testers.AnalyzerByRegion
-		ingest              *api.Ingest
-		recordObjectStoreId string
-		recordingSpec       *api.RecordingSpec
-		skipSourcePlayback  bool
-		useForceURL         bool
-		recordingWaitTime   time.Duration
-		useHTTP             bool
-		mp4                 bool
-		streamHealth        bool
-		serfOpts            SerfOptions
+		RecordTesterOptions
+		serfOpts SerfOptions
+
+		ctx    context.Context
+		cancel context.CancelFunc
 
 		// mutable fields
 		streamID string
@@ -88,19 +79,9 @@ type (
 func NewRecordTester(gctx context.Context, opts RecordTesterOptions, serfOpts SerfOptions) IRecordTester {
 	ctx, cancel := context.WithCancel(gctx)
 	rt := &recordTester{
-		lapi:                opts.API,
-		lanalyzers:          opts.Analyzers,
-		ingest:              opts.Ingest,
+		RecordTesterOptions: opts,
 		ctx:                 ctx,
 		cancel:              cancel,
-		recordObjectStoreId: opts.RecordObjectStoreId,
-		recordingSpec:       opts.RecordingSpec,
-		skipSourcePlayback:  opts.SkipSourcePlayback,
-		useForceURL:         opts.UseForceURL,
-		recordingWaitTime:   opts.RecordingWaitTime,
-		useHTTP:             opts.UseHTTP,
-		mp4:                 opts.TestMP4,
-		streamHealth:        opts.TestStreamHealth,
 		serfOpts:            serfOpts,
 	}
 	return rt
@@ -115,7 +96,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	}
 	apiTry := 0
 	for {
-		broadcasters, err = rt.lapi.Broadcasters()
+		broadcasters, err = rt.API.Broadcasters()
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++
@@ -129,9 +110,9 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	glog.V(model.DEBUG).Infof("Got broadcasters: %+v", broadcasters)
 	glog.V(model.DEBUG).Infof("Streaming video file '%s'\n", fileName)
 
-	if rt.useHTTP && len(broadcasters) == 0 {
+	if rt.UseHTTP && len(broadcasters) == 0 {
 		return 254, errors.New("empty list of broadcasters")
-	} else if (!rt.useHTTP && ingest.Ingest == "") || ingest.Playback == "" {
+	} else if (!rt.UseHTTP && ingest.Ingest == "") || ingest.Playback == "" {
 		return 254, errors.New("empty ingest URLs")
 	}
 
@@ -139,11 +120,11 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	streamName := fmt.Sprintf("%s_%s", hostName, time.Now().Format("2006-01-02T15:04:05Z07:00"))
 	var stream *api.Stream
 	for {
-		stream, err = rt.lapi.CreateStream(api.CreateStreamReq{
+		stream, err = rt.API.CreateStream(api.CreateStreamReq{
 			Name:                streamName,
 			Record:              true,
-			RecordingSpec:       rt.recordingSpec,
-			RecordObjectStoreId: rt.recordObjectStoreId,
+			RecordingSpec:       rt.RecordingSpec,
+			RecordObjectStoreId: rt.RecordObjectStoreId,
 		})
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
@@ -169,9 +150,9 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	rtmpURL := fmt.Sprintf("%s/%s", ingest.Ingest, stream.StreamKey)
 
 	testerFuncs := []testers.StartTestFunc{}
-	if rt.streamHealth {
+	if rt.TestStreamHealth {
 		testerFuncs = append(testerFuncs, func(ctx context.Context, mediaURL string, waitForTarget time.Duration, opts testers.Streamer2Options) testers.Finite {
-			return testers.NewStreamHealth(ctx, stream.ID, rt.lanalyzers, 2*time.Minute)
+			return testers.NewStreamHealth(ctx, stream.ID, rt.Analyzers, 2*time.Minute)
 		})
 	}
 
@@ -190,7 +171,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	}
 	glog.V(model.SHORT).Infof("RTMP: %s streamId=%s playbackId=%s", rtmpURL, stream.ID, stream.PlaybackID)
 	glog.V(model.SHORT).Infof("MEDIA: %s streamId=%s playbackId=%s", mediaURL, stream.ID, stream.PlaybackID)
-	if rt.useHTTP {
+	if rt.UseHTTP {
 		sterr := rt.doOneHTTPStream(fileName, streamName, broadcasters[0], testDuration, stream)
 		if sterr != nil {
 			glog.Warningf("Streaming returned error err=%v streamId=%s playbackId=%s", sterr, stream.ID, stream.PlaybackID)
@@ -261,18 +242,18 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 	}
 
 	lapiNoAPIKey := api.NewAPIClient(api.ClientOptions{
-		Server:      rt.lapi.GetServer(),
+		Server:      rt.API.GetServer(),
 		AccessToken: "", // test playback info call without API key
 		Timeout:     8 * time.Second,
 	})
-	if code, err := checkPlaybackInfo(stream.PlaybackID, rt.lapi, lapiNoAPIKey); err != nil {
+	if code, err := checkPlaybackInfo(stream.PlaybackID, rt.API, lapiNoAPIKey); err != nil {
 		return code, err
 	}
 
 	glog.Infof("Waiting 10 seconds. streamId=%s playbackId=%s", stream.ID, stream.PlaybackID)
 	time.Sleep(10 * time.Second)
 	// now get sessions
-	sessions, err := rt.lapi.GetSessionsNew(stream.ID, false)
+	sessions, err := rt.API.GetSessionsNew(stream.ID, false)
 	if err != nil {
 		glog.Errorf("Error getting sessions err=%v streamId=%s playbackId=%s", err, stream.ID, stream.PlaybackID)
 		return 252, err
@@ -307,8 +288,8 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 
 	glog.Infof("Streaming done, waiting for recording URL to appear. streamId=%s playbackId=%s", stream.ID, stream.PlaybackID)
 
-	deadline := time.Now().Add(rt.recordingWaitTime)
-	if rt.useForceURL {
+	deadline := time.Now().Add(rt.RecordingWaitTime)
+	if rt.UseForceURL {
 		deadline = time.Now().Add(5 * time.Second)
 	}
 
@@ -332,7 +313,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		for _, sess := range sessions {
 			// currently the assetID is the same as the sessionID so we could just query on that but just in case that
 			// ever changes, we can use the ListAssets call to find the asset
-			assets, _, err := rt.lapi.ListAssets(api.ListOptions{
+			assets, _, err := rt.API.ListAssets(api.ListOptions{
 				Limit: 1,
 				Filters: map[string]interface{}{
 					"sourceSessionId": sess.ID,
@@ -350,7 +331,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 			}
 			asset := assets[0]
 
-			if code, err := checkPlaybackInfo(asset.PlaybackID, rt.lapi, lapiNoAPIKey); err != nil {
+			if code, err := checkPlaybackInfo(asset.PlaybackID, rt.API, lapiNoAPIKey); err != nil {
 				errCode, errs = code, append(errs, err)
 			} else {
 				// if we get playback before the processing is done it means source playback was provided
@@ -365,12 +346,12 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 			}
 		}
 	}
-	if !sourcePlayback && !rt.skipSourcePlayback {
+	if !sourcePlayback && !rt.SkipSourcePlayback {
 		return 246, errors.New("source playback was not provided")
 	}
 
 	// check actual recordings playback
-	sessions, err = rt.lapi.GetSessionsNew(stream.ID, false)
+	sessions, err = rt.API.GetSessionsNew(stream.ID, false)
 	if err != nil {
 		glog.Errorf("Error getting sessions err=%v streamId=%s playbackId=%s", err, stream.ID, stream.PlaybackID)
 		return 252, err
@@ -386,7 +367,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 
 	for _, sess := range sessions {
 		statusShould := api.RecordingStatusReady
-		if rt.useForceURL {
+		if rt.UseForceURL {
 			statusShould = api.RecordingStatusWaiting
 		}
 		if sess.RecordingStatus != statusShould {
@@ -402,7 +383,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 		if err = rt.isCancelled(); err != nil {
 			return 0, err
 		}
-		if rt.mp4 {
+		if rt.TestMP4 {
 			es, err := rt.checkRecordingMp4(stream, sess.Mp4Url, testDuration)
 			if err != nil {
 				return es, err
@@ -420,7 +401,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 
 	glog.Infof("Done Record Test. streamId=%s playbackId=%s", stream.ID, stream.PlaybackID)
 
-	rt.lapi.DeleteStream(stream.ID)
+	rt.API.DeleteStream(stream.ID)
 	return 0, nil
 }
 
@@ -443,14 +424,14 @@ func checkPlaybackInfo(playbackID string, withKey, withoutKey *api.Client) (int,
 }
 
 func (rt *recordTester) getIngestInfo() (*api.Ingest, error) {
-	if rt.ingest != nil {
-		return rt.ingest, nil
+	if rt.Ingest != nil {
+		return rt.Ingest, nil
 	}
 	var ingests []api.Ingest
 	apiTry := 0
 	for {
 		var err error
-		ingests, err = rt.lapi.Ingest(false)
+		ingests, err = rt.API.Ingest(false)
 		if err != nil {
 			if testers.Timedout(err) && apiTry < 3 {
 				apiTry++
@@ -472,11 +453,11 @@ func (rt *recordTester) doOneHTTPStream(fileName, streamName, broadcasterURL str
 	var err error
 	apiTry := 0
 	for {
-		session, err = rt.lapi.CreateStream(api.CreateStreamReq{
+		session, err = rt.API.CreateStream(api.CreateStreamReq{
 			Name:                streamName,
 			Record:              true,
-			RecordingSpec:       rt.recordingSpec,
-			RecordObjectStoreId: rt.recordObjectStoreId,
+			RecordingSpec:       rt.RecordingSpec,
+			RecordObjectStoreId: rt.RecordObjectStoreId,
 			ParentID:            stream.ID,
 		})
 		if err != nil {
@@ -572,8 +553,8 @@ func (rt *recordTester) checkRecordingHls(stream *api.Stream, url string, stream
 	vs := downloader.VODStats()
 	rt.vodStats = vs
 	expectedProfiles := len(api.StandardProfiles) + 1
-	if rt.recordingSpec != nil && rt.recordingSpec.Profiles != nil {
-		expectedProfiles = len(*rt.recordingSpec.Profiles) + 1
+	if rt.RecordingSpec != nil && rt.RecordingSpec.Profiles != nil {
+		expectedProfiles = len(*rt.RecordingSpec.Profiles) + 1
 	}
 	if len(vs.SegmentsNum) != expectedProfiles {
 		glog.Warningf("Number of renditions doesn't match! Has %d should %d. streamId=%s playbackId=%s", len(vs.SegmentsNum), len(api.StandardProfiles)+1, stream.ID, stream.PlaybackID)
@@ -605,7 +586,7 @@ func (rt *recordTester) VODStats() model.VODStats {
 
 func (rt *recordTester) Clean() {
 	if rt.streamID != "" {
-		rt.lapi.DeleteStream(rt.streamID)
+		rt.API.DeleteStream(rt.streamID)
 	}
 }
 

--- a/internal/app/recordtester/recordtester_app.go
+++ b/internal/app/recordtester/recordtester_app.go
@@ -53,6 +53,7 @@ type (
 		Ingest              *api.Ingest
 		RecordObjectStoreId string
 		RecordingSpec       *api.RecordingSpec
+		SkipSourcePlayback  bool
 		UseForceURL         bool
 		RecordingWaitTime   time.Duration
 		UseHTTP             bool
@@ -68,6 +69,7 @@ type (
 		ingest              *api.Ingest
 		recordObjectStoreId string
 		recordingSpec       *api.RecordingSpec
+		skipSourcePlayback  bool
 		useForceURL         bool
 		recordingWaitTime   time.Duration
 		useHTTP             bool
@@ -93,6 +95,7 @@ func NewRecordTester(gctx context.Context, opts RecordTesterOptions, serfOpts Se
 		cancel:              cancel,
 		recordObjectStoreId: opts.RecordObjectStoreId,
 		recordingSpec:       opts.RecordingSpec,
+		skipSourcePlayback:  opts.SkipSourcePlayback,
 		useForceURL:         opts.UseForceURL,
 		recordingWaitTime:   opts.RecordingWaitTime,
 		useHTTP:             opts.UseHTTP,
@@ -362,7 +365,7 @@ func (rt *recordTester) Start(fileName string, testDuration, pauseDuration time.
 			}
 		}
 	}
-	if !sourcePlayback {
+	if !sourcePlayback && !rt.skipSourcePlayback {
 		return 246, errors.New("source playback was not provided")
 	}
 


### PR DESCRIPTION
- Allow skipping source playback checks with a `--skip-source-playback` flag
- Make number of profiles check required, while specifying the default profiles if not provided
- Also refactored `record-tester` a bit to avoid copying around option vars.

If anyone is reviewing this, go commit by commit as the above are kept separate.